### PR TITLE
use invoke workaround for Overdub{Execute}

### DIFF
--- a/src/workarounds.jl
+++ b/src/workarounds.jl
@@ -23,13 +23,7 @@ for nargs in 1:MAX_ARGS
         @inline execute(p::Val{true}, o::Overdub, $(args...)) = invoke(execute, Tuple{Val{true},Overdub,Vararg{Any}}, p, o, $(args...))
         @inline execute(p::Val{false}, o::Overdub, $(args...)) = invoke(execute, Tuple{Val{false},Overdub,Vararg{Any}}, p, o, $(args...))
 
-        # TODO: use invoke here as well; see https://github.com/jrevels/Cassette.jl/issues/5#issuecomment-341525276
-        @inline function (o::Overdub{Execute})($(args...))
-            prehook(o, $(args...))
-            output = execute(o, $(args...))
-            posthook(o, output, $(args...))
-            return output
-        end
+        @inline (o::Overdub{Execute})($(args...)) = invoke(o, Tuple{Vararg{Any}}, $(args...))
 
         # contextual/metadata.jl workarounds
         @inline mapcall(g, f, $(args...)) = invoke(mapcall, Tuple{Any,Any,Vararg{Any}}, g, f, $(args...))


### PR DESCRIPTION
Note this doesn't actually work yet; while https://github.com/JuliaLang/julia/pull/26301 fixes the [MWE here](https://github.com/jrevels/Cassette.jl/issues/5#issuecomment-341525276), it doesn't seem to fix the actual case exercised in this PR (unless I made a stupid typo or something)...

```julia
julia> using Cassette

julia> Cassette.@context Ctx

julia> o = Cassette.overdub(Ctx, sin)
Overdub{Execute}(Ctx, sin)

julia> o(1)
ERROR: StackOverflowError:
Stacktrace:
 [1] (::Cassette.Overdub{Cassette.Execute,typeof(float),Cassette.Settings{Ctx{0xeb4217858f960824},Cassette.Unused,0x0000000000006b93,false,Cassette.Unused}})(::Int64) at /Users/jarrettrevels/.julia/v0.7/Cassette/src/workarounds.jl:26 (repeats 26666 times)
```