### PR TITLE
make API macros accept normal method definitions by using default bindings for trace metadata, context, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Cassette.@context GPUCtx
 # is encountered that matches the signature of one of these primitives, that method call
 # will dispatch to the primitive definition provided here. For example, these definitions
 # will cause all `Base.sin(x)` calls to dispatch to `NativeGPUFunctions.sin(x)`.
-Cassette.@primitive GPUCtx (::typeof(Base.sin))(x::Number) = NativeGPUFunctions.sin(x)
-Cassette.@primitive GPUCtx (::typeof(Base.cos))(x::Number) = NativeGPUFunctions.cos(x)
-Cassette.@primitive GPUCtx (::typeof(Base.someotherfunction))(args...) = NativeGPUFunctions.someotherfunction(args...)
+Cassette.@primitive (::typeof(Base.sin))(x::Number) where {__CONTEXT__<:GPUCtx} = NativeGPUFunctions.sin(x)
+Cassette.@primitive (::typeof(Base.cos))(x::Number) where {__CONTEXT__<:GPUCtx} = NativeGPUFunctions.cos(x)
+Cassette.@primitive (::typeof(Base.someotherfunction))(args...) where {__CONTEXT__<:GPUCtx} = NativeGPUFunctions.someotherfunction(args...)
 ⋮ # pretend we do this for all the functions we care about
 
 f(args...) = # some function implemented in normal, GPU-unaware Julia code
@@ -73,8 +73,8 @@ julia> Cassette.@context CountCtx
 # Note here that we are dispatching on the type of trace-level metadata to define a prehook
 # that increments a counter every time one or more arguments of type `T` are encountered in
 # the execution trace.
-julia> Cassette.@prehook CountCtx c::Count{T} function f(arg::T, args::T...) where {T}
-           c.count += 1
+julia> Cassette.@prehook function f(arg::T, args::T...) where {T,__CONTEXT__<:CountCtx,__METADATA__<:Count{T}}
+           __trace__.metadata.count += 1
        end
 
 julia> f(x) = map(string, x)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Cassette relies on new reflection features and compiler performance improvements
 
 Cassette targets downstream package developers, not Julia end-users. Downstream developers are expected to have a solid understanding of Julia's type system, metaprogramming facilities, and dispatch mechanism.
 
-Last updated for Julia commit: 01939d4586247546e904c46efbe19ad78b482355
+Last updated for Julia commit: e542b28ac2acfe40ac2403cd7e67759e7faf72d5
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Cassette.@context GPUCtx
 # is encountered that matches the signature of one of these primitives, that method call
 # will dispatch to the primitive definition provided here. For example, these definitions
 # will cause all `Base.sin(x)` calls to dispatch to `NativeGPUFunctions.sin(x)`.
-Cassette.@primitive (::typeof(Base.sin))(x::Number) where {__CONTEXT__<:GPUCtx} = NativeGPUFunctions.sin(x)
-Cassette.@primitive (::typeof(Base.cos))(x::Number) where {__CONTEXT__<:GPUCtx} = NativeGPUFunctions.cos(x)
-Cassette.@primitive (::typeof(Base.someotherfunction))(args...) where {__CONTEXT__<:GPUCtx} = NativeGPUFunctions.someotherfunction(args...)
+Cassette.@primitive Base.sin(x::Number) where {__CONTEXT__<:GPUCtx} = NativeGPUFunctions.sin(x)
+Cassette.@primitive Base.cos(x::Number) where {__CONTEXT__<:GPUCtx} = NativeGPUFunctions.cos(x)
+Cassette.@primitive Base.someotherfunction(args...) where {__CONTEXT__<:GPUCtx} = NativeGPUFunctions.someotherfunction(args...)
 ⋮ # pretend we do this for all the functions we care about
 
 f(args...) = # some function implemented in normal, GPU-unaware Julia code
@@ -73,7 +73,7 @@ julia> Cassette.@context CountCtx
 # Note here that we are dispatching on the type of trace-level metadata to define a prehook
 # that increments a counter every time one or more arguments of type `T` are encountered in
 # the execution trace.
-julia> Cassette.@prehook function f(arg::T, args::T...) where {T,__CONTEXT__<:CountCtx,__METADATA__<:Count{T}}
+julia> Cassette.@prehook function (::Any)(arg::T, args::T...) where {T,__CONTEXT__<:CountCtx,__METADATA__<:Count{T}}
            __trace__.metadata.count += 1
        end
 

--- a/src/api/api.jl
+++ b/src/api/api.jl
@@ -70,7 +70,7 @@ end
 macro isprimitive(signature)
     body = Expr(:block)
     push!(body.args, :(return Val(true)))
-    return contextual_definition!(:($Cassette.isprimitive), signature, body)
+    return contextual_definition!(:($Cassette.is_user_primitive), signature, body)
 end
 
 ##############

--- a/src/workarounds.jl
+++ b/src/workarounds.jl
@@ -5,19 +5,14 @@ for nargs in 1:MAX_ARGS
     args = [Symbol("x$i") for i in 1:nargs]
     @eval begin
         # overdub/execution.jl workarounds
-        @inline _prehook(world::Val{w}, $(args...)) where {w} = invoke(_prehook, Tuple{Val{w},Vararg{Any}}, world, $(args...))
-        @inline _posthook(world::Val{w}, $(args...)) where {w} = invoke(_posthook, Tuple{Val{w},Vararg{Any}}, world, $(args...))
-        @inline _execution(world::Val{w}, ctx, meta, f, $(args...)) where {w} = invoke(_execution, Tuple{Val{w},Any,Any,Any,Vararg{Any}}, world, ctx, meta, f, $(args...))
-        @inline _isprimitive(world::Val{w}, $(args...)) where {w} = invoke(_isprimitive, Tuple{Val{w},Vararg{Any}}, world, $(args...))
+        @inline prehook(config::TraceConfig{C,M,w}, f, $(args...)) where {C,M,w} = invoke(prehook, Tuple{TraceConfig{C,M,w},Any,Vararg{Any}}, config, f, $(args...))
+        @inline posthook(config::TraceConfig{C,M,w}, f, $(args...)) where {C,M,w} = invoke(posthook, Tuple{TraceConfig{C,M,w},Any,Vararg{Any}}, config, f, $(args...))
+        @inline execution(config::TraceConfig{C,M,w}, f, $(args...)) where {C,M,w} = invoke(execution, Tuple{TraceConfig{C,M,w},Any,Vararg{Any}}, config, f, $(args...))
+        @inline isprimitive(config::TraceConfig{C,M,w}, f, $(args...)) where {C,M,w} = invoke(isprimitive, Tuple{TraceConfig{C,M,w},Any,Vararg{Any}}, config, f, $(args...))
 
-        @inline prehook(settings::Settings{C,M,w}, f, $(args...)) where {C,M,w} = invoke(prehook, Tuple{Settings{C,M,w},Any,Vararg{Any}}, settings, f, $(args...))
-        @inline posthook(settings::Settings{C,M,w}, f, $(args...)) where {C,M,w} = invoke(posthook, Tuple{Settings{C,M,w},Any,Vararg{Any}}, settings, f, $(args...))
-        @inline execution(settings::Settings{C,M,w}, f, $(args...)) where {C,M,w} = invoke(execution, Tuple{Settings{C,M,w},Any,Vararg{Any}}, settings, f, $(args...))
-        @inline isprimitive(settings::Settings{C,M,w}, f, $(args...)) where {C,M,w} = invoke(isprimitive, Tuple{Settings{C,M,w},Any,Vararg{Any}}, settings, f, $(args...))
-
-        @inline prehook(o::Overdub, $(args...)) = invoke(prehook, Tuple{Overdub,Vararg{Any}}, o, $(args...))
-        @inline posthook(o::Overdub, $(args...)) = invoke(posthook, Tuple{Overdub,Vararg{Any}}, o, $(args...))
-        @inline isprimitive(o::Overdub, $(args...)) = invoke(isprimitive, Tuple{Overdub,Vararg{Any}}, o, $(args...))
+        @inline prehook_overdub(o::Overdub, $(args...)) = invoke(prehook_overdub, Tuple{Overdub,Vararg{Any}}, o, $(args...))
+        @inline posthook_overdub(o::Overdub, $(args...)) = invoke(posthook_overdub, Tuple{Overdub,Vararg{Any}}, o, $(args...))
+        @inline isprimitive_overdub(o::Overdub, $(args...)) = invoke(isprimitive_overdub, Tuple{Overdub,Vararg{Any}}, o, $(args...))
 
         @inline execute(o::Overdub, $(args...)) = invoke(execute, Tuple{Overdub,Vararg{Any}}, o, $(args...))
         @inline execute(p::Val{true}, o::Overdub, $(args...)) = invoke(execute, Tuple{Val{true},Overdub,Vararg{Any}}, p, o, $(args...))
@@ -25,9 +20,9 @@ for nargs in 1:MAX_ARGS
 
         # TODO: use invoke here as well; see https://github.com/jrevels/Cassette.jl/issues/5#issuecomment-341525276
         @inline function (o::Overdub{Execute})($(args...))
-            prehook(o, $(args...))
+            prehook_overdub(o, $(args...))
             output = execute(o, $(args...))
-            posthook(o, output, $(args...))
+            posthook_overdub(o, output, $(args...))
             return output
         end
 

--- a/src/workarounds.jl
+++ b/src/workarounds.jl
@@ -5,14 +5,15 @@ for nargs in 1:MAX_ARGS
     args = [Symbol("x$i") for i in 1:nargs]
     @eval begin
         # overdub/execution.jl workarounds
-        @inline prehook(config::TraceConfig{C,M,w}, f, $(args...)) where {C,M,w} = invoke(prehook, Tuple{TraceConfig{C,M,w},Any,Vararg{Any}}, config, f, $(args...))
-        @inline posthook(config::TraceConfig{C,M,w}, f, $(args...)) where {C,M,w} = invoke(posthook, Tuple{TraceConfig{C,M,w},Any,Vararg{Any}}, config, f, $(args...))
-        @inline execution(config::TraceConfig{C,M,w}, f, $(args...)) where {C,M,w} = invoke(execution, Tuple{TraceConfig{C,M,w},Any,Vararg{Any}}, config, f, $(args...))
-        @inline isprimitive(config::TraceConfig{C,M,w}, f, $(args...)) where {C,M,w} = invoke(isprimitive, Tuple{TraceConfig{C,M,w},Any,Vararg{Any}}, config, f, $(args...))
+        @inline prehook(cfg::TraceConfig{C,M,w}, f, $(args...)) where {C,M,w} = invoke(prehook, Tuple{TraceConfig{C,M,w},Any,Vararg{Any}}, cfg, f, $(args...))
+        @inline posthook(cfg::TraceConfig{C,M,w}, f, $(args...)) where {C,M,w} = invoke(posthook, Tuple{TraceConfig{C,M,w},Any,Vararg{Any}}, cfg, f, $(args...))
+        @inline execution(cfg::TraceConfig{C,M,w}, f, $(args...)) where {C,M,w} = invoke(execution, Tuple{TraceConfig{C,M,w},Any,Vararg{Any}}, cfg, f, $(args...))
+        @inline is_user_primitive(cfg::TraceConfig{C,M,w}, f, $(args...)) where {C,M,w} = invoke(is_user_primitive, Tuple{TraceConfig{C,M,w},Any,Vararg{Any}}, cfg, f, $(args...))
+        @inline is_core_primitive(cfg::TraceConfig{C,M,w}, f, $(args...)) where {C,M,w} = invoke(is_core_primitive, Tuple{TraceConfig{C,M,w},Any,Vararg{Any}}, cfg, f, $(args...))
 
         @inline prehook_overdub(o::Overdub, $(args...)) = invoke(prehook_overdub, Tuple{Overdub,Vararg{Any}}, o, $(args...))
         @inline posthook_overdub(o::Overdub, $(args...)) = invoke(posthook_overdub, Tuple{Overdub,Vararg{Any}}, o, $(args...))
-        @inline isprimitive_overdub(o::Overdub, $(args...)) = invoke(isprimitive_overdub, Tuple{Overdub,Vararg{Any}}, o, $(args...))
+        @inline is_user_primitive_overdub(o::Overdub, $(args...)) = invoke(is_user_primitive_overdub, Tuple{Overdub,Vararg{Any}}, o, $(args...))
 
         @inline execute(o::Overdub, $(args...)) = invoke(execute, Tuple{Overdub,Vararg{Any}}, o, $(args...))
         @inline execute(p::Val{true}, o::Overdub, $(args...)) = invoke(execute, Tuple{Val{true},Overdub,Vararg{Any}}, p, o, $(args...))

--- a/test/ExecuteTests.jl
+++ b/test/ExecuteTests.jl
@@ -1,6 +1,7 @@
 module ExecuteTests
 
 using Test, Cassette
+using Cassette: @context, @prehook, @posthook, @primitive, @pass, overdub, Box
 
 ############################################################################################
 
@@ -16,22 +17,22 @@ end
 
 x = rand(2)
 
-Cassette.@context RosCtx
+@context RosCtx
 
 MESSAGES = String[]
-Cassette.@prehook RosCtx (f::Any)(args...) = push!(MESSAGES, string("calling ", f, args))
-@test Cassette.overdub(RosCtx, rosenbrock)(x) == rosenbrock(x)
+@prehook (f::Any)(args...) where {__CONTEXT__<:RosCtx} = push!(MESSAGES, string("calling ", f, args))
+@test overdub(RosCtx, rosenbrock)(x) == rosenbrock(x)
 @test length(MESSAGES) > 100
 
-Cassette.@prehook RosCtx meta (f::Any)(args...) = push!(meta, string("calling ", f, args))
+@prehook (f::Any)(args...) where {__CONTEXT__<:RosCtx} = push!(__trace__.metadata, string("calling ", f, args))
 meta = String[]
-@test Cassette.overdub(RosCtx, rosenbrock, metadata = meta)(x) == rosenbrock(x)
+@test overdub(RosCtx, rosenbrock, metadata = meta)(x) == rosenbrock(x)
 @test MESSAGES == meta
 
-Cassette.@prehook RosCtx meta (f::Any)(args...) = nothing
-Cassette.@prehook RosCtx meta (f::Any)(args::Number...) = push!(meta, args)
+@prehook (f::Any)(args...) where {__CONTEXT__<:RosCtx} = nothing
+@prehook (f::Any)(args::Number...) where {__CONTEXT__<:RosCtx} = push!(__trace__.metadata, args)
 meta = Any[]
-@test Cassette.overdub(RosCtx, rosenbrock, metadata = meta)(x) == rosenbrock(x)
+@test overdub(RosCtx, rosenbrock, metadata = meta)(x) == rosenbrock(x)
 for args in meta
     @test all(x -> isa(x, Number), args)
 end
@@ -40,45 +41,45 @@ end
 
 x = rand()
 sin_plus_cos(x) = sin(x) + cos(x)
-Cassette.@context SinCtx
-@test Cassette.overdub(SinCtx, sin_plus_cos)(x) === sin_plus_cos(x)
-Cassette.@primitive SinCtx sin(x) = cos(x)
-@test Cassette.overdub(SinCtx, sin_plus_cos)(x) === (2 * cos(x))
+@context SinCtx
+@test overdub(SinCtx, sin_plus_cos)(x) === sin_plus_cos(x)
+@primitive sin(x) where {__CONTEXT__<:SinCtx} = cos(x)
+@test overdub(SinCtx, sin_plus_cos)(x) === (2 * cos(x))
 
 ############################################################################################
 
 x = 2
 foldmul(x, args...) = Core._apply(Base.afoldl, (*, x), args...)
-Cassette.@context FoldCtx
-@test Cassette.overdub(FoldCtx, foldmul)(x) === foldmul(x)
+@context FoldCtx
+@test overdub(FoldCtx, foldmul)(x) === foldmul(x)
 
 ############################################################################################
 
-Cassette.@context CountCtx
+@context CountCtx
 count1 = Ref(0)
-Cassette.@prehook CountCtx count (f::Any)(args::Number...) = (count[] += 1)
-Cassette.overdub(CountCtx, sin, metadata = count1)(1)
-Cassette.@prehook CountCtx count (f::Any)(args::Number...) = (count[] += 2)
+@prehook (f::Any)(args::Number...) where {__CONTEXT__<:CountCtx} = (__trace__.metadata[] += 1)
+overdub(CountCtx, sin, metadata = count1)(1)
+@prehook (f::Any)(args::Number...) where {__CONTEXT__<:CountCtx} = (__trace__.metadata[] += 2)
 count2 = Ref(0)
-Cassette.overdub(CountCtx, sin, metadata = count2)(1)
+overdub(CountCtx, sin, metadata = count2)(1)
 @test (2 * count1[]) === count2[]
 
 ############################################################################################
 
 square_closure(x) = (y -> y * x)(x)
-Cassette.@context SqrCtx
+@context SqrCtx
 x = rand()
-@test square_closure(x) == Cassette.overdub(SqrCtx, square_closure)(x)
+@test square_closure(x) == overdub(SqrCtx, square_closure)(x)
 
 ############################################################################################
 
 comprehension1(x) = [i for i in x]
 comprehension2(f, x, y) = [f(x, i) for i in y]
-Cassette.@context CompCtx
+@context CompCtx
 f, x, y = hypot, rand(), rand(2)
-@test comprehension1(x) == Cassette.overdub(CompCtx, comprehension1)(x)
-@test comprehension1(y) == Cassette.overdub(CompCtx, comprehension1)(y)
-@test comprehension2(f, x, y) == Cassette.overdub(CompCtx, comprehension2)(f, x, y)
+@test comprehension1(x) == overdub(CompCtx, comprehension1)(x)
+@test comprehension1(y) == overdub(CompCtx, comprehension1)(y)
+@test comprehension2(f, x, y) == overdub(CompCtx, comprehension2)(f, x, y)
 
 ############################################################################################
 
@@ -90,11 +91,11 @@ end
 
 baz_identity(x::Int) = Baz(x, float(x), "$x").x
 
-Cassette.@context BazCtx
+@context BazCtx
 n = rand()
 ctx = BazCtx(baz_identity)
-result = Cassette.overdub(ctx, baz_identity)(Cassette.Box(ctx, 1, n))
-@test result === Cassette.Box(ctx, 1, n)
+result = overdub(ctx, baz_identity)(Box(ctx, 1, n))
+@test result === Box(ctx, 1, n)
 
 ############################################################################################
 
@@ -118,19 +119,19 @@ function foo_bar_identity(x)
     foo2.b.x
 end
 
-Cassette.@context FooBarCtx
+@context FooBarCtx
 n = rand()
 ctx = FooBarCtx(foo_bar_identity)
-result = Cassette.overdub(ctx, foo_bar_identity)(Cassette.Box(ctx, 1, n))
-@test result === Cassette.Box(ctx, 1, n)
+result = overdub(ctx, foo_bar_identity)(Box(ctx, 1, n))
+@test result === Box(ctx, 1, n)
 
 ############################################################################################
 
 sig_collection = DataType[]
-Cassette.@context PassCtx
+@context PassCtx
 tapepass(sig, cinfo) = (push!(sig_collection, sig); cinfo)
-Cassette.@pass TapePass tapepass
-Cassette.overdub(PassCtx, sum; pass = TapePass())(rand(3))
+@pass TapePass tapepass
+overdub(PassCtx, sum; pass = TapePass())(rand(3))
 @test !isempty(sig_collection) && all(T -> T <: Tuple, sig_collection)
 
 end # module ExecuteTests

--- a/test/ExecuteTests.jl
+++ b/test/ExecuteTests.jl
@@ -83,6 +83,9 @@ f, x, y = hypot, rand(), rand(2)
 
 ############################################################################################
 
+using Test, Cassette
+using Cassette: @context, @prehook, @posthook, @primitive, @pass, overdub, Box
+
 struct Baz
     x::Int
     y::Float64


### PR DESCRIPTION
This makes the API a tad more verbose, but much easier to explain, maintain, and extend. ~It should also make the rest of #30 quite easy to implement, since it exposes the entire configuration object.~ Okay, this now solves #30 by changing `isprimitive` to `is_user_primitive` and adds `is_core_primitive` (to e.g. determine recursive tracing base cases).

~Note that I actually implemented this last night while a bit tired, so I need to review it again to make sure I didn't forget something/make stupid typos...~ Tests now pass locally, so hopefully I didn't do anything *too* dumb...