### PR TITLE
Relabel :enter Exprs

### DIFF
--- a/src/api/api.jl
+++ b/src/api/api.jl
@@ -292,9 +292,9 @@ function contextual_definition!(f, signature::Expr, body::Expr)
     call_args = signature.args[1].args
     for i in 1:length(call_args)
         x = call_args[i]
-        if isa(x, Expr) && x.head == :(::)
+        if Base.Meta.isexpr(x, :(::))
             xtype = last(x.args)
-            if isa(xtype, Expr) && xtype.head == :macrocall && xtype.args[1] == Symbol("@Box")
+            if Base.Meta.isexpr(xtype, :macrocall) && xtype.args[1] == Symbol("@Box")
                 box_args = xtype.args[3:end]
                 if isempty(box_args)
                     U, M = :Any, :Any

--- a/src/contextual/anonymous.jl
+++ b/src/contextual/anonymous.jl
@@ -133,7 +133,7 @@ function translatefield(expr::Expr)
         if expr.args[1] == :mut && length(expr.args) == 2
             S = :Mutable
             inner = expr.args[2]
-            if isa(inner, Expr) && inner.head === :kw
+            if Base.Meta.isexpr(inner, :kw)
                 lhs, rhs = inner.args
             else
                 lhs, rhs = inner, nothing
@@ -145,7 +145,7 @@ function translatefield(expr::Expr)
         S = :Immutable
         lhs, rhs = expr.args
     end
-    name, T = (isa(lhs, Expr) && lhs.head == :(::)) ? lhs.args : (lhs, nothing)
+    name, T = Base.Meta.isexpr(lhs, :(::)) ? lhs.args : (lhs, nothing)
     if rhs === nothing
         @assert S === :Mutable
         data = T === nothing ? :($Cassette.Mutable{Any}()) : :($Cassette.Mutable{$T}())

--- a/src/overdub/execution.jl
+++ b/src/overdub/execution.jl
@@ -152,7 +152,7 @@ function overdub_pass!(method_body::CodeInfo)
     end
 
     # replace all `new` expressions with calls to `Cassette._newbox`
-    replace_match!(x -> isa(x, Expr) && x.head === :new, new_code) do x
+    replace_match!(x -> Base.Meta.isexpr(x, :new), new_code) do x
         return Expr(:call, GlobalRef(Cassette, :_newbox), ctx_ssa, x.args...)
     end
 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -51,6 +51,8 @@ function fix_labels_and_gotos!(code::Vector)
     for (i, stmnt) in enumerate(code)
         if isa(stmnt, GotoNode)
             code[i] = GotoNode(get(changes, stmnt.label, stmnt.label))
+        elseif isa(stmnt, Expr) && stmnt.head == :enter
+            stmnt.args[1] = get(changes, stmnt.args[1], stmnt.args[1])
         elseif isa(stmnt, Expr) && stmnt.head == :gotoifnot
             stmnt.args[2] = get(changes, stmnt.args[2], stmnt.args[2])
         end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -2,7 +2,7 @@
 # Expression Predicates #
 #########################
 
-is_call(x) = isa(x, Expr) && (x.head == :call) && (x.args[1] !== GlobalRef(Core, :tuple))
+is_call(x) = Base.Meta.isexpr(x, :call) && (x.args[1] !== GlobalRef(Core, :tuple))
 
 function is_method_definition(x)
     if isa(x, Expr)
@@ -51,9 +51,9 @@ function fix_labels_and_gotos!(code::Vector)
     for (i, stmnt) in enumerate(code)
         if isa(stmnt, GotoNode)
             code[i] = GotoNode(get(changes, stmnt.label, stmnt.label))
-        elseif isa(stmnt, Expr) && stmnt.head == :enter
+        elseif Base.Meta.isexpr(stmnt, :enter)
             stmnt.args[1] = get(changes, stmnt.args[1], stmnt.args[1])
-        elseif isa(stmnt, Expr) && stmnt.head == :gotoifnot
+        elseif Base.Meta.isexpr(stmnt, :gotoifnot)
             stmnt.args[2] = get(changes, stmnt.args[2], stmnt.args[2])
         end
     end


### PR DESCRIPTION
Otherwise exceptions break the compiler.

Also changes from `isa(x, Expr) && x.head == y` to `Meta.isexpr` (but using `Base.Meta` because Cassette defines a `struct Meta`).