### PR TITLE
Make Cassette more eloquent

### DIFF
--- a/src/Cassette.jl
+++ b/src/Cassette.jl
@@ -4,6 +4,8 @@ module Cassette
 
 using Core: CodeInfo, SlotNumber, NewvarNode, LabelNode, GotoNode, SSAValue, arrayref, arrayset
 
+using Logging
+
 struct Unused end
 
 abstract type Context end
@@ -27,5 +29,13 @@ include("reflection.jl")
 include("execution.jl")
 include("macros.jl")
 include("workarounds.jl")
+
+function __init__()
+    # FIXME: Base should provide a mechanism for this (eg. Julia/julia#26265)
+    DEBUG = parse(Bool, get(ENV, "DEBUG", "false"))
+    if DEBUG
+        global_logger(ConsoleLogger(global_logger().stream, Logging.Debug))
+    end
+end
 
 end # module

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -175,18 +175,18 @@ function overdub_transform_call_generator(::Type{F}, ::Type{C}, ::Type{M}, world
             method_body = overdub_pass!(method_body, boxes)
             method_body.inlineable = true
             method_body.signature_for_inference_heuristics = Core.svec(ftype, atypes, world)
-            debug && Core.println("RETURNING OVERDUBBED CODEINFO: ", sprint(show, method_body))
+            @safe_debug "returning overdubbed codeinfo" method_body
         else
             method_body = quote
                 $(Expr(:meta, :inline))
                 $Cassette.execution(f.config, f.func, $(OVERDUB_ARGS_SYMBOL)...)
             end
-            debug && Core.println("NO CODEINFO FOUND; EXECUTING AS PRIMITIVE")
+            @safe_debug "no codeinfo found; executing as primitive"
         end
         return method_body
     catch err
+        @safe_error "error compiling" signature context=C
         errmsg = "ERROR COMPILING $signature IN CONTEXT $C: " * sprint(showerror, err)
-        Core.println(errmsg) # in case the returned body doesn't get reached
         return quote
             error($errmsg)
         end

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -6,7 +6,6 @@ const BEGIN_OVERDUB_REGION = gensym("cassette_begin_overdub_region")
 # if it exists in the method table. Otherwise, return `nothing`.
 function lookup_method_body(::Type{S};
                             world::UInt = typemax(UInt),
-                            debug::Bool = false,
                             pass::DataType = Unused) where {S<:Tuple}
     @safe_debug "looking up method" signature=S world=world
     S.parameters[1].name.module === Core.Compiler && return nothing

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -8,12 +8,7 @@ function lookup_method_body(::Type{S};
                             world::UInt = typemax(UInt),
                             debug::Bool = false,
                             pass::DataType = Unused) where {S<:Tuple}
-    if debug
-        Core.println("-----------------------------------")
-        Core.println("LOOKING UP CODEINFO FOR:")
-        Core.println("\tSIGNATURE: ", S)
-        Core.println("\tWORLD: ", world)
-    end
+    @safe_debug "looking up method" signature=S world=world
     S.parameters[1].name.module === Core.Compiler && return nothing
 
     # retrieve initial Method + CodeInfo
@@ -26,8 +21,7 @@ function lookup_method_body(::Type{S};
     code_info = Core.Compiler.retrieve_code_info(method_instance)
     isa(code_info, CodeInfo) || return nothing
     code_info = Core.Compiler.copy_code_info(code_info)
-    debug && Core.println("FOUND METHOD: ", sprint(show, method))
-    debug && Core.println("FOUND CODEINFO: ", sprint(show, code_info))
+    @safe_debug "retrieved initial method" method code_info
 
     # execute user-provided pass if present
     if !(pass <: Unused)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -86,3 +86,21 @@ function unqualify_name(e::Expr)
 end
 
 unqualify_name(name::Symbol) = name
+
+# define safe loggers for use in generated functions (where task switches are not allowed)
+for level in [:debug, :info, :warn, :error]
+    @eval begin
+        macro $(Symbol("safe_$level"))(ex...)
+            macrocall = :(@placeholder $(ex...))
+            # NOTE: `@placeholder` in order to avoid hard-coding @__LINE__ etc
+            macrocall.args[1] = Symbol($"@$level")
+            quote
+                old_logger = global_logger()
+                global_logger(Logging.ConsoleLogger(Core.stderr, old_logger.min_level))
+                ret = $(esc(macrocall))
+                global_logger(old_logger)
+                ret
+            end
+        end
+    end
+end


### PR DESCRIPTION
I didn't like how it was always shouting at me.

The new Logging output also looks much better, because of indentation and proper stringification:

```
$ DEBUG=true julia -e 'using Cassette; Cassette.overdub(Cassette.@context(Ctx), println)("Hello, World!")'
┌ Debug: looking up method
│   signature = Tuple{typeof(println),String}
│   world = 0x0000000000006ba3
└ @ Cassette utilities.jl:94
┌ Debug: retrieved initial method
│   method = println(xs...) in Base at coreio.jl:4
│   code_info =
│    CodeInfo(:(begin
│          nothing
│          Core.SSAValue(0) = (Core.typeassert)(Base.stdout, Base.IO)
│          Core.SSAValue(1) = (Core.tuple)(Core.SSAValue(0))
│          Core.SSAValue(2) = (Core._apply)(Base.println, Core.SSAValue(1), xs)
│          return Core.SSAValue(2)
│      end))
└ @ Cassette utilities.jl:94
┌ Debug: returning overdubbed codeinfo
│   method_body =
│    CodeInfo(:(begin
│          nothing
│          Core.SSAValue(4) = (Cassette.func)(#self#)
│          Core.SSAValue(5) = (Cassette.context)(#self#)
│          Core.SSAValue(3) = (Core.getfield)(##cassette_overdub_arguments#1524, 1)
│          xs = (Core.tuple)(Core.SSAValue(3))
│          Core.SSAValue(6) = (Cassette.proceed)(#self#, Core.typeassert)
│          Core.SSAValue(0) = (Core.SSAValue(6))(Base.stdout, Base.IO)
│          Core.SSAValue(1) = (Core.tuple)(Core.SSAValue(0))
│          Core.SSAValue(7) = (Cassette.proceed)(#self#, Core._apply)
│          Core.SSAValue(2) = (Core.SSAValue(7))(Base.println, Core.SSAValue(1), xs)
│          return Core.SSAValue(2)
│      end))
└ @ Cassette utilities.jl:94
┌ Debug: looking up method
│   signature = Tuple{typeof(typeassert),Base.TTY,Type{IO}}
│   world = 0x0000000000006ba3
└ @ Cassette utilities.jl:94
┌ Debug: no codeinfo found; executing as primitive
└ @ Cassette utilities.jl:94
┌ Debug: looking up method
│   signature = Tuple{typeof(Core._apply),typeof(println),Tuple{Base.TTY},Tuple{String}}
│   world = 0x0000000000006ba3
└ @ Cassette utilities.jl:94
┌ Debug: no codeinfo found; executing as primitive
└ @ Cassette utilities.jl:94
Hello, World!
```