### PR TITLE
[WIP] bring back metadata propagation (but instead of `Box`es, we now have `Tagged` objects)

### DIFF
--- a/src/Cassette.jl
+++ b/src/Cassette.jl
@@ -18,6 +18,7 @@ abstract type AbstractContext{T<:AbstractTag,P<:AbstractPass,B} end
 include("utilities.jl")
 include("tagged.jl")
 include("overdub.jl")
+include("contextdef.jl")
 include("macros.jl")
 
 function __init__()

--- a/src/Cassette.jl
+++ b/src/Cassette.jl
@@ -7,8 +7,8 @@ using Core: CodeInfo, SlotNumber, NewvarNode, LabelNode, GotoNode, SSAValue
 using Logging
 
 abstract type AbstractPass end
-struct UnusedPass <: AbstractPass end
-(::Type{UnusedPass})(::Any, ::Any, code_info) = code_info
+struct NoPass <: AbstractPass end
+(::Type{NoPass})(::Any, ::Any, code_info) = code_info
 
 abstract type AbstractTag end
 struct BottomTag <: AbstractTag end

--- a/src/Cassette.jl
+++ b/src/Cassette.jl
@@ -6,8 +6,6 @@ using Core: CodeInfo, SlotNumber, NewvarNode, LabelNode, GotoNode, SSAValue
 
 using Logging
 
-struct UnusedMeta end
-
 abstract type AbstractPass end
 struct UnusedPass <: AbstractPass end
 (::Type{UnusedPass})(::Any, ::Any, code_info) = code_info
@@ -18,6 +16,7 @@ struct BottomTag <: AbstractTag end
 abstract type AbstractContext{P<:AbstractPass,T<:AbstractTag} end
 
 include("utilities.jl")
+include("tagged.jl")
 include("overdub.jl")
 include("macros.jl")
 

--- a/src/Cassette.jl
+++ b/src/Cassette.jl
@@ -6,14 +6,14 @@ using Core: CodeInfo, SlotNumber, NewvarNode, LabelNode, GotoNode, SSAValue
 
 using Logging
 
+abstract type AbstractTag end
+struct BottomTag <: AbstractTag end
+
 abstract type AbstractPass end
 struct NoPass <: AbstractPass end
 (::Type{NoPass})(::Any, ::Any, code_info) = code_info
 
-abstract type AbstractTag end
-struct BottomTag <: AbstractTag end
-
-abstract type AbstractContext{P<:AbstractPass,T<:AbstractTag} end
+abstract type AbstractContext{T<:AbstractTag,P<:AbstractPass,B} end
 
 include("utilities.jl")
 include("tagged.jl")

--- a/src/contextdef.jl
+++ b/src/contextdef.jl
@@ -1,0 +1,116 @@
+#######################
+# unhygeniec bindings #
+#######################
+
+const CONTEXT_TYPE_BINDING = Symbol("__CONTEXT__")
+const CONTEXT_BINDING = Symbol("__context__")
+
+###################
+# stubs/utilities #
+###################
+
+# these stubs are only overloaded on a per-context basis
+function generate_tag end
+function similar_context end
+
+# this @pure annotations has official vtjnash approval :p
+Base.@pure pure_objectid(x) = objectid(x)
+
+###########################################
+# context definition generation from name #
+###########################################
+
+function generate_context_definition(Ctx)
+    @assert isa(Ctx, Symbol) "context name must be a Symbol"
+    CtxTag = gensym(string(Ctx, "Tag"))
+    return quote
+        struct $CtxTag{E,H} <: $Cassette.AbstractTag end
+
+        $CtxTag(x) = $CtxTag($Cassette.BottomTag(), x)
+        $CtxTag(::E, ::X) where {E,X} = $CtxTag{E,$Cassette.pure_objectid(X)}()
+
+        struct $Ctx{M,T<:$CtxTag,P<:$Cassette.AbstractPass,B<:Union{Nothing,$Cassette.BindingMetaCache}} <: $Cassette.AbstractContext{T,P,B}
+            metadata::M
+            tag::T
+            pass::P
+            bindings::B # tagging functionality is considered disabled if this field is `nothing`
+        end
+
+        function $Ctx(;
+                      metadata = nothing,
+                      pass::$Cassette.AbstractPass = $Cassette.NoPass(),
+                      tagging_enabled::Bool = false)
+            bindings = tagging_enabled ? $Cassette.BindingMetaCache() : nothing
+            return $Ctx(metadata, $CtxTag(nothing), pass, bindings)
+        end
+
+        $Cassette.generate_tag(ctx::$Ctx, f) = $CtxTag(f)
+
+        function $Cassette.similar_context(ctx::$Ctx;
+                                           metadata = ctx.metadata,
+                                           tag = ctx.tag,
+                                           pass = ctx.pass,
+                                           bindings = ctx.bindings)
+            return $Ctx(metadata, tag, pass, bindings)
+        end
+
+        #=== default primitives ===#
+
+        $Cassette.@primitive function $CtxTag(x) where {__CONTEXT__<:$Ctx}
+            return $CtxTag(__context__.tag, x)
+        end
+
+        $Cassette.@primitive function Core._apply(f, args...) where {__CONTEXT__<:$Ctx}
+            flattened_args = Core._apply(tuple, args...)
+            return $Cassette.overdub_execute(__context__, f, flattened_args...)
+        end
+
+        $Cassette.@primitive function Array{T,N}(undef::UndefInitializer, args...) where {T,N,__CONTEXT__<:$Ctx}
+            return $Cassette.tagged_new(__context__, Array{T,N}, undef, args...)
+        end
+
+        $Cassette.@primitive function Base.nameof(m) where {__CONTEXT__<:$Ctx}
+            return $Cassette.tagged_nameof(__context__, m)
+        end
+
+        $Cassette.@primitive function Core.getfield(x, name) where {__CONTEXT__<:$Ctx}
+            return $Cassette.tagged_getfield(__context__, x, name)
+        end
+
+        $Cassette.@primitive function Core.setfield!(x, name, y) where {__CONTEXT__<:$Ctx}
+            return $Cassette.tagged_setfield!(__context__, x, name, y)
+        end
+
+        $Cassette.@primitive function Core.arrayref(boundscheck, x, i) where {__CONTEXT__<:$Ctx}
+            return $Cassette.tagged_arrayref(__context__, boundscheck, x, i)
+        end
+
+        $Cassette.@primitive function Core.arrayset(boundscheck, x, y, i) where {__CONTEXT__<:$Ctx}
+            return $Cassette.tagged_arrayset(__context__, boundscheck, x, y, i)
+        end
+
+        $Cassette.@primitive function Base._growbeg!(x, delta) where {__CONTEXT__<:$Ctx}
+            return $Cassette.tagged_growbeg!(__context__, x, delta)
+        end
+
+        $Cassette.@primitive function Base._growend!(x, delta) where {__CONTEXT__<:$Ctx}
+            return $Cassette.tagged_growend!(__context__, x, delta)
+        end
+
+        $Cassette.@primitive function Base._growat!(x, i, delta) where {__CONTEXT__<:$Ctx}
+            return $Cassette.tagged_growat!(__context__, x, i, delta)
+        end
+
+        $Cassette.@primitive function Base._deletebeg!(x, delta) where {__CONTEXT__<:$Ctx}
+            return $Cassette.tagged_deletebeg!(__context__, x, delta)
+        end
+
+        $Cassette.@primitive function Base._deleteend!(x, delta) where {__CONTEXT__<:$Ctx}
+            return $Cassette.tagged_deleteend!(__context__, x, delta)
+        end
+
+        $Cassette.@primitive function Base._deleteat!(x, i, delta) where {__CONTEXT__<:$Ctx}
+            return $Cassette.tagged_deleteat!(__context__, x, i, delta)
+        end
+    end
+end

--- a/src/contextdef.jl
+++ b/src/contextdef.jl
@@ -33,7 +33,7 @@ function generate_context_definition(Ctx)
             metadata::M
             tag::T
             pass::P
-            bindings::B # tagging functionality is considered disabled if this field is `nothing`
+            bindings::B # tagging functionality is considered enabled if this field is of type `BindingMetaCache`
         end
 
         function $Ctx(;
@@ -65,7 +65,8 @@ function generate_context_definition(Ctx)
             return $Cassette.overdub_execute(__context__, f, flattened_args...)
         end
 
-        $Cassette.@primitive function Array{T,N}(undef::UndefInitializer, args...) where {T,N,__CONTEXT__<:$Ctx}
+        # dispatch on `B` to ensure that we don't call this when tagging is disabled
+        $Cassette.@primitive function Array{T,N}(undef::UndefInitializer, args...) where {T,N,__CONTEXT__<:$Ctx{<:Any,<:Any,<:Any,$Cassette.BindingMetaCache}}
             return $Cassette.tagged_new(__context__, Array{T,N}, undef, args...)
         end
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -54,10 +54,12 @@ macro context(Ctx)
             return $Ctx(metadata, pass, tag, metamodules)
         end
 
-        # default primitives/execution definitions
+        #=== default primitives/execution definitions ===#
+
         $Cassette.@primitive function $CtxTag(x) where {__CONTEXT__<:$Ctx}
             return $CtxTag(__context__.tag, x)
         end
+
         $Cassette.@execution function Core._apply(f, args...) where {__CONTEXT__<:$Ctx}
             flattened_args = Core._apply(tuple, args...)
             return $Cassette.overdub_execute(__context__, f, flattened_args...)
@@ -67,8 +69,8 @@ macro context(Ctx)
         #     Array{T,N}(...) -> tagged_new(...)
         #     getfield(...) -> tagged_load(...)
         #     setfield!(...) -> tagged_store!(...)
-        #     getindex(::Array, ::Int) -> tagged_load(...)
-        #     setindex!(::Array, ::Any, ::Int) -> tagged_store!(...)
+        #     arrayref(::Bool, ::Array, ::Int) -> tagged_load(...)
+        #     arrayset(::Bool, ::Array, ::Any, ::Int) -> tagged_store!(...)
         #     _growbeg!(...) -> tagged_growbeg!(...)
         #     _growat!(...) -> tagged_growat!(...)
         #     _growend!(...) -> tagged_growend!(...)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -39,7 +39,7 @@ macro context(Ctx)
 
         function $Ctx(;
                       metadata = nothing,
-                      pass::$Cassette.AbstractPass = $Cassette.UnusedPass(),
+                      pass::$Cassette.AbstractPass = $Cassette.NoPass(),
                       metamodules = $Cassette.MetaModuleCache())
             return $Ctx(metadata, pass, $CtxTag(nothing), metamodules)
         end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -60,7 +60,7 @@ macro context(Ctx)
             return $CtxTag(__context__.tag, x)
         end
 
-        $Cassette.@execution function Core._apply(f, args...) where {__CONTEXT__<:$Ctx}
+        $Cassette.@primitive function Core._apply(f, args...) where {__CONTEXT__<:$Ctx}
             flattened_args = Core._apply(tuple, args...)
             return $Cassette.overdub_execute(__context__, f, flattened_args...)
         end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -34,14 +34,14 @@ macro context(Ctx)
             metadata::M
             pass::P
             tag::T
-            metamodules::$Cassette.MetaModuleCache
+            bindings::$Cassette.BindingMetaCache
         end
 
         function $Ctx(;
                       metadata = nothing,
                       pass::$Cassette.AbstractPass = $Cassette.NoPass(),
-                      metamodules = $Cassette.MetaModuleCache())
-            return $Ctx(metadata, pass, $CtxTag(nothing), metamodules)
+                      bindings = $Cassette.BindingMetaCache())
+            return $Ctx(metadata, pass, $CtxTag(nothing), bindings)
         end
 
         $Cassette.generate_tag(ctx::$Ctx, f) = $CtxTag(f)
@@ -50,8 +50,8 @@ macro context(Ctx)
                                            metadata = ctx.metadata,
                                            pass = ctx.pass,
                                            tag = ctx.tag,
-                                           metamodules = ctx.metamodules)
-            return $Ctx(metadata, pass, tag, metamodules)
+                                           bindings = ctx.bindings)
+            return $Ctx(metadata, pass, tag, bindings)
         end
 
         #=== default primitives/execution definitions ===#
@@ -77,6 +77,7 @@ macro context(Ctx)
         #     _deletebeg!(...) -> tagged_deletebeg!(...)
         #     _deleteat!(...) -> tagged_deleteat!(...)
         #     _deleteend!(...) -> tagged_deleteend!(...)
+        #     nameof(::Module) -> tagged_nameof(...)
     end)
 end
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -319,6 +319,8 @@ function typify_signature(signature)
     error("malformed signature: $signature")
 end
 
+# TODO: bring back `@Tagged`?
+
 function contextual_definition!(f, method)
     @assert is_method_definition(method)
     signature, body = method.args

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1,20 +1,6 @@
-#######################
-# unhygeniec bindings #
-#######################
-
-const CONTEXT_TYPE_BINDING = Symbol("__CONTEXT__")
-const CONTEXT_BINDING = Symbol("__context__")
-
 ############
 # @context #
 ############
-
-# these stubs are only overloaded on a per-context basis
-function generate_tag end
-function similar_context end
-
-# this @pure annotations has official vtjnash approval :p
-Base.@pure pure_objectid(x) = objectid(x)
 
 """
     Cassette.@context Ctx
@@ -22,98 +8,7 @@ Base.@pure pure_objectid(x) = objectid(x)
 Define a new Cassette context type with the name `Ctx`.
 """
 macro context(Ctx)
-    @assert isa(Ctx, Symbol) "context name must be a Symbol"
-    CtxTag = gensym(string(Ctx, "Tag"))
-    return esc(quote
-        struct $CtxTag{E,H} <: $Cassette.AbstractTag end
-
-        $CtxTag(x) = $CtxTag($Cassette.BottomTag(), x)
-        $CtxTag(::E, ::X) where {E,X} = $CtxTag{E,$Cassette.pure_objectid(X)}()
-
-        struct $Ctx{M,T<:$CtxTag,P<:$Cassette.AbstractPass,B<:Union{Nothing,$Cassette.BindingMetaCache}} <: $Cassette.AbstractContext{T,P,B}
-            metadata::M
-            tag::T
-            pass::P
-            bindings::B # tagging functionality is considered disabled if this field is `nothing`
-        end
-
-        function $Ctx(;
-                      metadata = nothing,
-                      pass::$Cassette.AbstractPass = $Cassette.NoPass(),
-                      tagging_enabled::Bool = false)
-            bindings = tagging_enabled ? $Cassette.BindingMetaCache() : nothing
-            return $Ctx(metadata, $CtxTag(nothing), pass, bindings)
-        end
-
-        $Cassette.generate_tag(ctx::$Ctx, f) = $CtxTag(f)
-
-        function $Cassette.similar_context(ctx::$Ctx;
-                                           metadata = ctx.metadata,
-                                           tag = ctx.tag,
-                                           pass = ctx.pass,
-                                           bindings = ctx.bindings)
-            return $Ctx(metadata, tag, pass, bindings)
-        end
-
-        #=== default primitives ===#
-
-        $Cassette.@primitive function $CtxTag(x) where {__CONTEXT__<:$Ctx}
-            return $CtxTag(__context__.tag, x)
-        end
-
-        $Cassette.@primitive function Core._apply(f, args...) where {__CONTEXT__<:$Ctx}
-            flattened_args = Core._apply(tuple, args...)
-            return $Cassette.overdub_execute(__context__, f, flattened_args...)
-        end
-
-        $Cassette.@primitive function Array{T,N}(undef::UndefInitializer, args...) where {T,N,__CONTEXT__<:$Ctx}
-            return $Cassette.tagged_new(__context__, Array{T,N}, undef, args...)
-        end
-
-        $Cassette.@primitive function Base.nameof(m) where {__CONTEXT__<:$Ctx}
-            return $Cassette.tagged_nameof(__context__, m)
-        end
-
-        $Cassette.@primitive function Core.getfield(x, name) where {__CONTEXT__<:$Ctx}
-            return $Cassette.tagged_getfield(__context__, x, name)
-        end
-
-        $Cassette.@primitive function Core.setfield!(x, name, y) where {__CONTEXT__<:$Ctx}
-            return $Cassette.tagged_setfield!(__context__, x, name, y)
-        end
-
-        $Cassette.@primitive function Core.arrayref(boundscheck, x, i) where {__CONTEXT__<:$Ctx}
-            return $Cassette.tagged_arrayref(__context__, boundscheck, x, i)
-        end
-
-        $Cassette.@primitive function Core.arrayset(boundscheck, x, y, i) where {__CONTEXT__<:$Ctx}
-            return $Cassette.tagged_arrayset(__context__, boundscheck, x, y, i)
-        end
-
-        $Cassette.@primitive function Base._growbeg!(x, delta) where {__CONTEXT__<:$Ctx}
-            return $Cassette.tagged_growbeg!(__context__, x, delta)
-        end
-
-        $Cassette.@primitive function Base._growend!(x, delta) where {__CONTEXT__<:$Ctx}
-            return $Cassette.tagged_growend!(__context__, x, delta)
-        end
-
-        $Cassette.@primitive function Base._growat!(x, i, delta) where {__CONTEXT__<:$Ctx}
-            return $Cassette.tagged_growat!(__context__, x, i, delta)
-        end
-
-        $Cassette.@primitive function Base._deletebeg!(x, delta) where {__CONTEXT__<:$Ctx}
-            return $Cassette.tagged_deletebeg!(__context__, x, delta)
-        end
-
-        $Cassette.@primitive function Base._deleteend!(x, delta) where {__CONTEXT__<:$Ctx}
-            return $Cassette.tagged_deleteend!(__context__, x, delta)
-        end
-
-        $Cassette.@primitive function Base._deleteat!(x, i, delta) where {__CONTEXT__<:$Ctx}
-            return $Cassette.tagged_deleteat!(__context__, x, i, delta)
-        end
-    end)
+    return esc(generate_context_definition(Ctx))
 end
 
 ############
@@ -318,8 +213,6 @@ function typify_signature(signature)
     end
     error("malformed signature: $signature")
 end
-
-# TODO: bring back `@Tagged`?
 
 function contextual_definition!(f, method)
     @assert is_method_definition(method)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -32,12 +32,14 @@ macro context(Ctx)
             metadata::M
             pass::P
             tag::T
+            metamodules::$Cassette.MetaModuleCache
         end
 
         function $Ctx(;
-                      metadata = $Cassette.UnusedMeta(),
-                      pass::$Cassette.AbstractPass = $Cassette.UnusedPass())
-            return $Ctx(metadata, pass, $CtxTag(nothing))
+                      metadata = nothing,
+                      pass::$Cassette.AbstractPass = $Cassette.UnusedPass(),
+                      metamodules = $Cassette.MetaModuleCache())
+            return $Ctx(metadata, pass, $CtxTag(nothing), metamodules)
         end
 
         $Cassette.generate_tag(ctx::$Ctx, f) = $CtxTag(f)
@@ -45,8 +47,9 @@ macro context(Ctx)
         function $Cassette.similar_context(ctx::$Ctx;
                                            metadata = ctx.metadata,
                                            pass = ctx.pass,
-                                           tag = ctx.tag)
-            return $Ctx(metadata, pass, tag)
+                                           tag = ctx.tag,
+                                           metamodules = ctx.metamodules)
+            return $Ctx(metadata, pass, tag, metamodules)
         end
 
         # default primitives/execution definitions
@@ -57,6 +60,19 @@ macro context(Ctx)
             flattened_args = Core._apply(tuple, args...)
             return $Cassette.overdub_execute(__context__, f, flattened_args...)
         end
+
+        # TODO: add contextual primitives for:
+        #     Array{T,N}(...) -> tagged_new(...)
+        #     getfield(...) -> tagged_load(...)
+        #     setfield!(...) -> tagged_store!(...)
+        #     getindex(::Array, ::Int) -> tagged_load(...)
+        #     setindex!(::Array, ::Any, ::Int) -> tagged_store!(...)
+        #     _growbeg!(...) -> tagged_growbeg!(...)
+        #     _growat!(...) -> tagged_growat!(...)
+        #     _growend!(...) -> tagged_growend!(...)
+        #     _deletebeg!(...) -> tagged_deletebeg!(...)
+        #     _deleteat!(...) -> tagged_deleteat!(...)
+        #     _deleteend!(...) -> tagged_deleteend!(...)
     end)
 end
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -13,6 +13,9 @@ const CONTEXT_BINDING = Symbol("__context__")
 function generate_tag end
 function similar_context end
 
+# this @pure annotations has official vtjnash approval :p
+Base.@pure pure_objectid(x) = objectid(x)
+
 """
     Cassette.@context Ctx
 
@@ -24,9 +27,8 @@ macro context(Ctx)
     return esc(quote
         struct $CtxTag{E,H} <: $Cassette.AbstractTag end
 
-        # these @pure annotations have official vtjnash approval :p
-        Base.@pure $CtxTag(x) = $CtxTag($Cassette.BottomTag(), x)
-        Base.@pure $CtxTag(::E, ::X) where {E,X} = $CtxTag{E,objectid(X)}()
+        $CtxTag(x) = $CtxTag($Cassette.BottomTag(), x)
+        $CtxTag(::E, ::X) where {E,X} = $CtxTag{E,$Cassette.pure_objectid(X)}()
 
         struct $Ctx{M,P<:$Cassette.AbstractPass,T<:$CtxTag} <: $Cassette.AbstractContext{P,T}
             metadata::M

--- a/src/overdub.jl
+++ b/src/overdub.jl
@@ -134,7 +134,7 @@ function overdub_recurse_pass!(reflection::Reflection,
 end
 
 # `args` is `(typeof(original_function), map(typeof, original_args_tuple)...)`
-function overdub_recurse_generator(pass_type, self, context_type, args::Tuple)
+function overdub_recurse_generator(tag_type, pass_type, self, context_type, args::Tuple)
     try
         reflection = reflect(args) # TODO unboxtype `args`
         if isa(reflection, Reflection)
@@ -160,14 +160,14 @@ end
 
 function overdub_recurse_definition(pass, line, file)
     return quote
-        function overdub_recurse($OVERDUB_CTX_SYMBOL::AbstractContext{pass}, $OVERDUB_ARGS_SYMBOL...) where {pass<:$pass}
+        function overdub_recurse($OVERDUB_CTX_SYMBOL::AbstractContext{tag,pass}, $OVERDUB_ARGS_SYMBOL...) where {tag,pass<:$pass}
             $(Expr(:meta,
                    :generated,
                    Expr(:new,
                         Core.GeneratedFunctionStub,
                         :overdub_recurse_generator,
                         Any[:overdub_recurse, OVERDUB_CTX_SYMBOL, OVERDUB_ARGS_SYMBOL],
-                        Any[:pass],
+                        Any[:tag, :pass],
                         line,
                         QuoteNode(Symbol(file)),
                         true)))

--- a/src/overdub.jl
+++ b/src/overdub.jl
@@ -50,7 +50,7 @@ const OVERDUB_ARGS_SYMBOL = gensym("overdub_arguments")
 # this function.
 function overdub_recurse_pass!(reflection::Reflection,
                                context_type::DataType,
-                               pass_type::DataType = UnusedPass)
+                               pass_type::DataType = NoPass)
     signature = reflection.signature
     method = reflection.method
     static_params = reflection.static_params
@@ -175,4 +175,4 @@ function overdub_recurse_definition(pass, line, file)
     end
 end
 
-@eval $(overdub_recurse_definition(:UnusedPass, @__LINE__, @__FILE__))
+@eval $(overdub_recurse_definition(:NoPass, @__LINE__, @__FILE__))

--- a/src/overdub.jl
+++ b/src/overdub.jl
@@ -125,8 +125,9 @@ function overdub_recurse_pass!(reflection::Reflection,
         push!(overdubbed_code, stmnt)
     end
 
-    # Replace `new` expressions with calls to `Cassette.tagged_new`.
-    # TODO
+    # TODO: Replace `new` expressions with calls to `Cassette.tagged_new`.
+
+    # TODO: appropriately untag all `gotoifnot` conditionals
 
     code_info.code = fix_labels_and_gotos!(overdubbed_code)
     code_info.method_for_inference_limit_heuristics = method

--- a/src/tagged.jl
+++ b/src/tagged.jl
@@ -1,0 +1,213 @@
+##################
+# `FieldStorage` #
+##################
+
+abstract type FieldStorage{D} end
+
+#=== `Mutable` ===#
+
+mutable struct Mutable{D} <: FieldStorage{D}
+    data::D
+    Mutable{D}() where D = new{D}()
+    Mutable{D}(data) where D = new{D}(data)
+end
+
+@inline load(x::Mutable) = x.data
+
+@inline store!(x::Mutable, y) = (x.data = y)
+
+#=== `Immutable` ===#
+
+struct Immutable{D} <: FieldStorage{D}
+    data::D
+    Immutable{D}(data) where D = new{D}(data)
+end
+
+@inline load(x::Immutable) = x.data
+
+@inline store!(x::Immutable, y) = error("cannot mutate immutable field")
+
+##########
+# `Meta` #
+##########
+
+struct NoMetaData end
+struct NoMetaFields end
+
+struct Meta{D,F#=<:Union{NamedTuple,Array,MetaModule}=#}
+    data::Union{D,NoMetaData}
+    fields::Union{F,NoMetaFields}
+end
+
+# These defined to allow conversion of `Meta(NoMetaData,NoMetaFields)`
+# into whatever metatype is expected by a container.
+Base.convert(::Type{M}, meta::M) where {M<:Meta} = meta
+Base.convert(::Type{Meta{D,F}}, meta::Meta) where {D,F} = Meta{D,F}(meta.data, meta.fields)
+
+# TODO metatype specification (should be relatively easy to port from the old implementation)
+
+############
+# `Tagged` #
+############
+
+struct Tagged{T<:AbstractTag,U,V,D,F}
+    tag::T
+    value::V
+    meta::Meta{D,F}
+    function Tagged(tag::T, value::V, meta::Meta{D,F}) where {T<:AbstractTag,V,D,F}
+        return new{T,_underlying_type(V),V,D,F}(tag, value, meta)
+    end
+end
+
+#=== `Tagged` internals ===#
+
+_underlying_type(::Type{V}) where {V} = V
+_underlying_type(::Type{<:Tagged{<:AbstractTag,U}}) where {U} = U
+
+#=== `Tagged` API ===#
+
+function tag(context::AbstractContext, value, metadata = NoMetaData())
+    return Tagged(context.tag, value, initmeta(context, value, metadata))
+end
+
+untag(x, context::AbstractContext) = untag(x, context.tag)
+untag(x::Tagged{T}, tag::T) where {T<:AbstractTag} = x.value
+untag(x, tag::AbstractTag) = x
+
+untagtype(::Type{X}, ::Type{<:AbstractContext{P,T}}) where {X,P,T} = untagtype(X, T)
+untagtype(::Type{<:Tagged{T,U,V}}, ::Type{T}) where {T<:AbstractTag,U,V} = V
+untagtype(::Type{X}, ::Type{<:AbstractTag}) = X
+
+metadata(x, context::AbstractContext) = metadata(x, context.tag)
+metadata(x::Tagged{T}, tag::T) where {T<:AbstractTag} = x.meta.data
+metadata(x, tag::AbstractTag) = NoMetaData()
+
+istagged(x, context::AbstractContext) = istagged(x, context.tag)
+istagged(x::Tagged{T}, tag::T) where {T<:AbstractTag} = true
+istagged(x, tag::AbstractTag) = false
+
+hasmetadata(x, context::AbstractContext) = hasmetadata(x, context.tag)
+hasmetadata(x, tag::AbstractTag) = isa(metadata(x, tag), NoMetaData)
+
+################
+# `tagged_new` #
+################
+
+@generated function tagged_new(context::C, ::Type{T}, args...) where {C<:AbstractContext,T}
+
+end
+
+@generated function tagged_new(context::C, ::Type{T}, args...) where {C<:AbstractContext,T<:Array}
+
+end
+
+# TODO: tagged_new for Module?
+
+@generated function _new(::Type{T}, args...) where {T}
+    return quote
+        $(Expr(:meta, :inline))
+        $(Expr(:new, T, [:(args[$i]) for i in 1:nfields(args)]...))
+    end
+end
+
+###################################
+# `Module`/`GlobalRef` Primitives #
+###################################
+
+const MetaModule = Dict{Symbol,Any}
+const MetaModuleCache = IdDict{Module,Meta{NoMetaData,MetaModule}}
+
+# TODO We actually need to be able to call this kind of function at IR-generation
+# time, as opposed to at runtime. This is because, for fast methods (~ns), this fetch
+# can cost drastically more than the primal method invocation. We easily have the
+# module at IR-generation time, but we don't have access to the actual context
+# object, implying we need to store/access this metamodule cache somewhere
+# else...
+function fetch_tagged_module(context::AbstractContext, m::Module)
+    if haskey(context.metamodules, m)
+        _m = context.metamodules[m]
+    else
+        _m = Meta(NoMetaData(), MetaModule())
+        context.metamodules[m] = _m
+    end
+    return Tagged(context.tag, m, _m::Meta{NoMetaData,MetaModule})
+end
+
+function _tagged_global_ref(m::Tagged, binding::Symbol, primal)
+    return tagged_global_ref(m.tag, m.value, m.meta.fields, binding, primal)
+end
+
+function tagged_global_ref(tag::AbstractTag, m::Module, _m::MetaModule, binding::Symbol, primal)
+    if isconst(m, binding) && isbits(primal)
+        # It's very important that this fast path exists and is taken with no runtime
+        # overhead; this is the path that will be taken by, for example, access of simple
+        # named function bindings.
+        return primal
+    else
+        # TODO: create entry in _m if not already available
+        # TODO: typeassert `_m[binding]`
+        return Tagged(tag, primal, _m[binding])
+    end
+end
+
+function _tagged_global_ref_set_meta!(m::Tagged, binding::Symbol, primal)
+    # TODO
+end
+
+#################
+# `tagged_load` #
+#################
+
+_tagged_load(x::Tagged, y) = tagged_load(x.tag, x.value, x.meta.fields, untag(y, x.tag))
+
+function tagged_load(tag::AbstractTag, x::Array, _x::Array, index)
+    return Tagged(tag, x[index], _x[index])
+end
+
+function tagged_load(tag::AbstractTag, x::Module, _x::MetaModule, binding)
+    return tagged_global_ref(tag, x, _x, binding, getfield(x, binding))
+end
+
+function tagged_load(tag::AbstractTag, x, _x::NamedTuple, field)
+    return Tagged(tag, getfield(x, field), load(getfield(_x, field)))
+end
+
+###################
+# `tagged_store!` #
+###################
+
+function _tagged_store!(x::Tagged, y, item)
+    item_meta = istagged(item, x.tag) ? item.meta : Meta(NoMetaData(), NoMetaFields())
+    return tagged_store!(x.tag, x.value, x.meta.fields,
+                         untag(y, x.tag), untag(item, x.tag),
+                         item_meta)
+end
+
+function tagged_store!(tag::AbstractTag, x::Array, _x::Array, index, item_value, item_meta)
+    x[index] = item_value
+    _x[index] = item_meta
+    return nothing
+end
+
+function tagged_store!(tag::AbstractTag, x::Module, _x::MetaModule, binding, item_value, item_meta)
+    # Julia doesn't have a valid `setfield!`` for `Modules`, so we
+    # should never run into this case in well-formed code anyway
+    error("cannot assign variables in other modules")
+end
+
+function tagged_store!(tag::AbstractTag, x, _x::NamedTuple, field, item_value, item_meta)
+    setfield!(x, field, item_value)
+    store!(getfield(_x, field), item_meta)
+    return nothing
+end
+
+############################
+# Other `Array` Primitives #
+############################
+# TODO
+# _growbeg!
+# _growat!
+# _growend!
+# _deletebeg!
+# _deleteat!
+# _deleteend!

--- a/src/tagged.jl
+++ b/src/tagged.jl
@@ -340,7 +340,11 @@ hasmetadata(x, tag::AbstractTag) = !isa(metadata(x, tag), NoMetaData)
 end
 
 @generated function tagged_new(context::C, ::Type{T}, args...) where {C<:AbstractContext,T<:Array}
-    # TODO
+    untagged_args = [:(untagged(args[$i], context)) for i in 1:nfields(args)]
+    return quote
+        $(Expr(:meta, :inline))
+        return tag(context, $(T)($(untagged_args...)))
+    end
 end
 
 @generated function tagged_new(context::C, ::Type{Module}, args...) where {C<:AbstractContext}

--- a/src/tagged.jl
+++ b/src/tagged.jl
@@ -97,7 +97,6 @@ function fetch_binding_meta!(context::AbstractContext,
     return convert(M, _fetch_binding_meta!(context, m, bindings, name).data)::M
 end
 
-
 ############################
 # `metatype` specification #
 ############################
@@ -359,7 +358,7 @@ end
 
 function tagged_globalref(context::AbstractContext{T},
                           m::Tagged{T},
-                          name::Symbol,
+                          name,
                           primal) where {T}
     if hasmetameta(m, context)
         return _tagged_globalref(context, m, name, primal)
@@ -370,15 +369,16 @@ end
 
 function _tagged_globalref(context::AbstractContext{T},
                            m::Tagged{T},
-                           name::Symbol,
+                           name,
                            primal) where {T}
-    if isconst(m.value, name) && isbits(primal)
+    untagged_name = untag(name, context)
+    if isconst(m.value, untagged_name) && isbits(primal)
         # It's very important that this fast path exists and is taken with no runtime
         # overhead; this is the path that will be taken by, for example, access of simple
         # named function bindings.
         return primal
     else
-        meta = fetch_binding_meta!(context, m.value, m.meta.meta.bindings, name, primal)
+        meta = fetch_binding_meta!(context, m.value, m.meta.meta.bindings, untagged_name, primal)
         return Tagged(context.tag, primal, meta)
     end
 end

--- a/src/tagged.jl
+++ b/src/tagged.jl
@@ -419,11 +419,51 @@ end
 ####################
 # Other Primitives #
 ####################
-# TODO
-# nameof
-# _growbeg!
-# _growat!
-# _growend!
-# _deletebeg!
-# _deleteat!
-# _deleteend!
+
+function tagged_nameof(context::AbstractContext{T}, x::Tagged{T,Module}) where {T}
+    return Tagged(context, nameof(x.value), x.meta.name)
+end
+
+function tagged_growbeg!(context::AbstractContext{T}, x::Tagged{T,<:Array}, delta) where {T}
+    delta_untagged = untag(delta, context)
+    Base._growbeg!(x.value, delta_untagged)
+    Base._growbeg!(x.meta.meta, delta_untagged)
+    return nothing
+end
+
+function tagged_growend!(context::AbstractContext{T}, x::Tagged{T,<:Array}, delta) where {T}
+    delta_untagged = untag(delta, context)
+    Base._growend!(x.value, delta_untagged)
+    Base._growend!(x.meta.meta, delta_untagged)
+    return nothing
+end
+
+function tagged_growat!(context::AbstractContext{T}, x::Tagged{T,<:Array}, i, delta) where {T}
+    i_untagged = untag(i, context)
+    delta_untagged = untag(delta, context)
+    Base._growat!(x.value, i_untagged, delta_untagged)
+    Base._growat!(x.meta.meta, i_untagged, delta_untagged)
+    return nothing
+end
+
+function tagged_deletebeg!(context::AbstractContext{T}, x::Tagged{T,<:Array}, delta) where {T}
+    delta_untagged = untag(delta, context)
+    Base._deletebeg!(x.value, delta_untagged)
+    Base._deletebeg!(x.meta.meta, delta_untagged)
+    return nothing
+end
+
+function tagged_deleteend!(context::AbstractContext{T}, x::Tagged{T,<:Array}, delta) where {T}
+    delta_untagged = untag(delta, context)
+    Base._deleteend!(x.value, delta_untagged)
+    Base._deleteend!(x.meta.meta, delta_untagged)
+    return nothing
+end
+
+function tagged_deleteat!(context::AbstractContext{T}, x::Tagged{T,<:Array}, i, delta) where {T}
+    i_untagged = untag(i, context)
+    delta_untagged = untag(delta, context)
+    Base._deleteat!(x.value, i_untagged, delta_untagged)
+    Base._deleteat!(x.meta.meta, i_untagged, delta_untagged)
+    return nothing
+end

--- a/src/tagged.jl
+++ b/src/tagged.jl
@@ -211,7 +211,7 @@ istaggedtype(::Type{<:Tagged{T}}, ::Type{T}) where {T<:AbstractTag} = true
 istaggedtype(::Type{<:Any}, ::Type{<:AbstractTag}) = false
 
 hasmetadata(x, context::AbstractContext) = hasmetadata(x, context.tag)
-hasmetadata(x, tag::AbstractTag) = isa(metadata(x, tag), NoMetaData)
+hasmetadata(x, tag::AbstractTag) = !isa(metadata(x, tag), NoMetaData)
 
 ################
 # `tagged_new` #

--- a/src/tagged.jl
+++ b/src/tagged.jl
@@ -366,7 +366,7 @@ end
 #################
 
 function _tagged_load(context::AbstractContext{T}, x::Tagged{T}, y, args...) where {T}
-    return tagged_load(context, x.value, x.meta.fields, untag(y, context), args...)
+    return tagged_load(context, x.value, x.meta.meta, untag(y, context), args...)
 end
 
 function tagged_load(context::AbstractContext, x::Array, _x::Array, index, boundscheck)
@@ -375,8 +375,8 @@ function tagged_load(context::AbstractContext, x::Array, _x::Array, index, bound
                   Core.arrayref(boundscheck, _x, index))
 end
 
-function tagged_load(context::AbstractContext, x::Module, _x::MetaModule, binding)
-    return tagged_module_load(context, x, _x, binding, getfield(x, binding))
+function tagged_load(context::AbstractContext, x::Module, _x::ModuleMeta, binding)
+    return _tagged_global_ref(context, x, _x.bindings, binding, getfield(x, binding))
 end
 
 function tagged_load(context::AbstractContext, x, _x::Union{NamedTuple,Tuple}, field)
@@ -388,7 +388,7 @@ end
 ###################
 
 function _tagged_store!(context::AbstractContext{T}, x::Tagged{T}, y, item, args...) where {T}
-    return tagged_store!(context, x.value, x.meta.fields,
+    return tagged_store!(context, x.value, x.meta.meta,
                          untag(y, context), untag(item, context),
                          istagged(item, context) ? item.meta : NOMETA,
                          args...)
@@ -400,7 +400,7 @@ function tagged_store!(context::AbstractContext, x::Array, _x::Array, index, ite
     return nothing
 end
 
-function tagged_store!(context::AbstractContext, x::Module, _x::MetaModule, binding, item_value, item_meta)
+function tagged_store!(context::AbstractContext, x::Module, _x::ModuleMeta, binding, item_value, item_meta)
     # Julia doesn't have a valid `setfield!`` for `Modules`, so we
     # should never run into this case in well-formed code anyway
     error("cannot assign variables in other modules")

--- a/src/tagged.jl
+++ b/src/tagged.jl
@@ -71,7 +71,7 @@ end
 
 However, this is an expensive implementation of this operation. Thus, our actual `metatype`
 implementation returns a still-correct, but extremely pessimistic metatype with the
-benefit that metatype computation is very fast. If, in the future, `metaype` is
+benefit that metatype computation is very fast. If, in the future, `metatype` is
 parameterized on world age, then we can call `subtypes` at compile time, and compute a more
 optimally bounded metatype.
 =#

--- a/test/ExampleTests.jl
+++ b/test/ExampleTests.jl
@@ -265,6 +265,7 @@ end
 ############################################################################################
 # TODO: The below is a highly pathological function for metadata propagation; we should turn
 # it into an actual test
+
 #=
 const const_binding = Float64[]
 
@@ -278,13 +279,22 @@ mutable struct FooContainer
     foo::Foo
 end
 
+mutable struct MulFunc
+    x::Float64
+end
+
+(m::MulFunc)(x) = m.x * x
+
+const mulfunc = MulFunc(1.0)
+
 function f(x::Vector{Float64}, y::Vector{Float64})
     @assert length(x) === length(y)
     x = FooContainer(Foo(x))
     for i in 1:length(y)
         v = x.foo.vector[i]
         push!(const_binding, v)
-        global global_binding *= v
+        global global_binding *= mulfunc(v)
+        mulfunc.x = v
         x.foo = Foo(y)
         y = x.foo.vector
     end


### PR DESCRIPTION
This is actually quite similar to the old `Box`es implementation in a lot of ways, but it's underpinned by a new design that's a bit more formalized. I'm writing up documentation on this design, which I'll add during the Cassette documentation pass (something I should try to do within the next month or so).

This implementation of the `Module`/`GlobalRef` handling might change a bit for the sake of performance, but what's here should at least capture the spirit of the new design.

I've tried to make sure to add TODOs in the code for all the actual items that still need to be completed before this PR is mergeable; there's still a good amount of them.