### PR TITLE
some inferability workarounds

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -40,8 +40,9 @@ macro context(Ctx)
         # relies upon constant propagation to infer, such as `isdispatchtuple`. Such
         # functions should generally be contextual primitives by default for the sake of
         # performance, and we should add more of them here as we encounter them.
-        $Cassette.@isprimitive Base.isdispatchtuple(T::Type) where {__CONTEXT__<:$Ctx}
-        $Cassette.@isprimitive Base.eltype(T::Type) where {__CONTEXT__<:$Ctx}
+        $Cassette.@isprimitive Base.isdispatchtuple(::Type) where {__CONTEXT__<:$Ctx}
+        $Cassette.@isprimitive Base.eltype(::Type) where {__CONTEXT__<:$Ctx}
+        $Cassette.@isprimitive Base.convert(::Type, ::Tuple) where {__CONTEXT__<:$Ctx}
 
         # enforce `T<:Cassette.Tag` to ensure that we only call the below primitive functions
         # if the context has the tagging system enabled

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -36,6 +36,12 @@ macro context(Ctx)
             return $Cassette.execute(__context__, p.func, args...)
         end
 
+        # TODO: There are certain non-`Core.Builtin` functions which the compiler generally
+        # relies upon constant propagation to infer, such as `isdispatchtuple`. Such
+        # functions should generally be contextual primitives by default for the sake of
+        # performance, and we should add more of them here as we encounter them.
+        $Cassette.@isprimitive Base.isdispatchtuple(T::Type) where {__CONTEXT__<:$Ctx}
+
         # enforce `T<:Cassette.Tag` to ensure that we only call the below primitive functions
         # if the context has the tagging system enabled
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -36,7 +36,7 @@ macro context(Ctx)
             return $Cassette.execute(__context__, p.func, args...)
         end
 
-        # TODO: There are certain non-`Core.Builtin` functions which the compiler generally
+        # TODO: There are certain non-`Core.Builtin` functions which the compiler often
         # relies upon constant propagation to infer, such as `isdispatchtuple`. Such
         # functions should generally be contextual primitives by default for the sake of
         # performance, and we should add more of them here as we encounter them.

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -41,6 +41,7 @@ macro context(Ctx)
         # functions should generally be contextual primitives by default for the sake of
         # performance, and we should add more of them here as we encounter them.
         $Cassette.@isprimitive Base.isdispatchtuple(T::Type) where {__CONTEXT__<:$Ctx}
+        $Cassette.@isprimitive Base.eltype(T::Type) where {__CONTEXT__<:$Ctx}
 
         # enforce `T<:Cassette.Tag` to ensure that we only call the below primitive functions
         # if the context has the tagging system enabled

--- a/src/overdub.jl
+++ b/src/overdub.jl
@@ -10,6 +10,14 @@
 @inline call(context::Context, f, args...) = untag(f, context)(ntuple(i -> untag(args[i], context), Val(nfields(args)))...)
 @inline canrecurse(ctx::Context, f, args...) = !isa(untag(f, ctx), Core.Builtin)
 
+# TODO: These are currently needed to force the compiler to specialize on certain core type
+# operations, e.g. `Core.apply_type`. In the future, it would be best for Julia's compiler
+# to better handle varargs calls to such functions, or at least provide a better way to force
+# specialization on the argument types.
+@inline call(::ContextWithTag{Nothing}, f::Core.Builtin, ::Type{A}) where {A} = f(A)
+@inline call(::ContextWithTag{Nothing}, f::Core.Builtin, ::Type{A}, ::Type{B}) where {A,B} = f(A, B)
+@inline call(::ContextWithTag{Nothing}, f::Core.Builtin, ::Type{A}, ::Type{B}, ::Type{C}) where {A,B,C} = f(A, B, C)
+
 ###########
 # overdub #
 ###########

--- a/src/overdub.jl
+++ b/src/overdub.jl
@@ -10,13 +10,12 @@
 @inline call(context::Context, f, args...) = untag(f, context)(ntuple(i -> untag(args[i], context), Val(nfields(args)))...)
 @inline canrecurse(ctx::Context, f, args...) = !isa(untag(f, ctx), Core.Builtin)
 
-# TODO: These are currently needed to force the compiler to specialize on certain core type
-# operations, e.g. `Core.apply_type`. In the future, it would be best for Julia's compiler
-# to better handle varargs calls to such functions, or at least provide a better way to force
-# specialization on the argument types.
-@inline call(::ContextWithTag{Nothing}, f::Core.Builtin, ::Type{A}) where {A} = f(A)
-@inline call(::ContextWithTag{Nothing}, f::Core.Builtin, ::Type{A}, ::Type{B}) where {A,B} = f(A, B)
-@inline call(::ContextWithTag{Nothing}, f::Core.Builtin, ::Type{A}, ::Type{B}, ::Type{C}) where {A,B,C} = f(A, B, C)
+# TODO: This is currently needed to force the compiler to specialize on the type arguments
+# to `Core.apply_type`. In the future, it would be best for Julia's compiler to better handle
+# varargs calls to such functions with type arguments, or at least provide a better way to
+# force specialization on the type arguments.
+@inline call(::ContextWithTag{Nothing}, f::typeof(Core.apply_type), ::Type{A}, ::Type{B}) where {A,B} = f(A, B)
+@inline call(::Context, f::typeof(Core.apply_type), ::Type{A}, ::Type{B}) where {A,B} = f(A, B)
 
 ###########
 # overdub #

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -453,7 +453,7 @@ dispatchtupletest(::Type{T}) where {T} = Base.isdispatchtuple(Tuple{T}) ? T : An
 @inferred(overdub(InferCtx(), *, rand(Float32, 1, 1), rand(Float32, 1, 1)))
 @inferred(overdub(InferCtx(), *, rand(Float32, 1, 1), rand(Float32, 1)))
 @inferred(overdub(InferCtx(), rosenbrock, rand(1)))
-@test_broken @inferred(overdub(InferCtx(), rand, Float32, 1))
+@inferred(overdub(InferCtx(), rand, Float32, 1))
 
 ############################################################################################
 #= TODO: The rest of the tests below should be restored for the metadata tagging system

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -442,11 +442,17 @@ Y_copy_out = LinearAlgebra.BLAS.gemv!('T', α, A, X, β, Y_copy)
 ############################################################################################
 
 @context TypeJoinInferCtx
-@inferred(overdub(TypeJoinInferCtx(), typejoin, Float32, Float32, Float32))
-
-#= TODO: The rest of the tests below should be restored for the metadata tagging system
+ctyped = @code_typed(overdub(TypeJoinInferCtx(), typejoin, Float32, Float32, Float32))
+@test ctyped.second === Type{Float32}
 
 ############################################################################################
+
+@context ApplyTypeInferCtx
+ctyped = @code_typed(overdub(ApplyTypeInferCtx(), (a, b) -> Core.apply_type(a, b), AbstractVector, Int))
+@test ctyped.second === Type{AbstractVector{Int}}
+
+############################################################################################
+#= TODO: The rest of the tests below should be restored for the metadata tagging system
 
 @context NestedCtx
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -452,6 +452,13 @@ ctyped = @code_typed(overdub(ApplyTypeInferCtx(), (a, b) -> Core.apply_type(a, b
 @test ctyped.second === Type{AbstractVector{Int}}
 
 ############################################################################################
+
+@context DispatchTupleInferCtx
+dispatchtupletest(::Type{T}) where {T} = Base.isdispatchtuple(Tuple{T}) ? T : Any
+ctyped = @code_typed(overdub(DispatchTupleInferCtx(), dispatchtupletest, Float32))
+@test ctyped.second === Type{Float32}
+
+############################################################################################
 #= TODO: The rest of the tests below should be restored for the metadata tagging system
 
 @context NestedCtx

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -450,6 +450,7 @@ dispatchtupletest(::Type{T}) where {T} = Base.isdispatchtuple(Tuple{T}) ? T : An
 @inferred(overdub(InferCtx(), (a, b) -> Core.apply_type(a, b), AbstractVector, Int))
 @inferred(overdub(InferCtx(), eltype, rand(1)))
 @inferred(overdub(InferCtx(), *, rand(1, 1), rand(1, 1)))
+@inferred(overdub(InferCtx(), *, rand(Float32, 1, 1), rand(Float32, 1, 1)))
 @inferred(overdub(InferCtx(), rosenbrock, rand(1)))
 @test_broken @inferred(overdub(InferCtx(), rand, Float32, 1))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -441,22 +441,17 @@ Y_copy_out = LinearAlgebra.BLAS.gemv!('T', α, A, X, β, Y_copy)
 
 ############################################################################################
 
-@context TypeJoinInferCtx
-ctyped = @code_typed(overdub(TypeJoinInferCtx(), typejoin, Float32, Float32, Float32))
-@test ctyped.second === Type{Float32}
+@context InferCtx
 
-############################################################################################
-
-@context ApplyTypeInferCtx
-ctyped = @code_typed(overdub(ApplyTypeInferCtx(), (a, b) -> Core.apply_type(a, b), AbstractVector, Int))
-@test ctyped.second === Type{AbstractVector{Int}}
-
-############################################################################################
-
-@context DispatchTupleInferCtx
 dispatchtupletest(::Type{T}) where {T} = Base.isdispatchtuple(Tuple{T}) ? T : Any
-ctyped = @code_typed(overdub(DispatchTupleInferCtx(), dispatchtupletest, Float32))
-@test ctyped.second === Type{Float32}
+
+@inferred(overdub(InferCtx(), typejoin, Float32, Float32, Float32))
+@inferred(overdub(InferCtx(), dispatchtupletest, Float32))
+@inferred(overdub(InferCtx(), (a, b) -> Core.apply_type(a, b), AbstractVector, Int))
+@inferred(overdub(InferCtx(), eltype, rand(1)))
+@inferred(overdub(InferCtx(), *, rand(1, 1), rand(1, 1)))
+@inferred(overdub(InferCtx(), rosenbrock, rand(1)))
+@test_broken @inferred(overdub(InferCtx(), rand, Float32, 1))
 
 ############################################################################################
 #= TODO: The rest of the tests below should be restored for the metadata tagging system

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -451,6 +451,7 @@ dispatchtupletest(::Type{T}) where {T} = Base.isdispatchtuple(Tuple{T}) ? T : An
 @inferred(overdub(InferCtx(), eltype, rand(1)))
 @inferred(overdub(InferCtx(), *, rand(1, 1), rand(1, 1)))
 @inferred(overdub(InferCtx(), *, rand(Float32, 1, 1), rand(Float32, 1, 1)))
+@inferred(overdub(InferCtx(), *, rand(Float32, 1, 1), rand(Float32, 1)))
 @inferred(overdub(InferCtx(), rosenbrock, rand(1)))
 @test_broken @inferred(overdub(InferCtx(), rand, Float32, 1))
 


### PR DESCRIPTION
needed for #53 

Not sure whether it merits opening an issue in Base Julia; I'm assuming the lack of specialization by default ([as mentioned here](https://github.com/jrevels/Cassette.jl/issues/53#issuecomment-405255104)) is an intentional barrier to overspecialization. @vtjnash Is this worth pursuing a  "fix" in the compiler?