### PR TITLE
untag conditional values in gotoifnot nodes

### DIFF
--- a/src/tagged.jl
+++ b/src/tagged.jl
@@ -69,8 +69,9 @@ end
 
 # TODO: For fast methods (~ns), this fetch can cost drastically more than the primal method
 # invocation. We easily have the module at compile time, but we don't have access to the
-# actual context object. This `@pure` is vtjnash-approved. It should allow the compiler to
-# optimize away the fetch once we have support for it, e.g. loop invariant code motion.
+# actual context object (just the type). This `@pure` is vtjnash-approved. It should allow
+# the compiler to optimize away the fetch once we have support for it, e.g. loop invariant
+# code motion.
 Base.@pure @noinline function fetch_tagged_module(context::Context, m::Module)
     bindings = get!(() -> BindingMetaDict(), context.bindings, m)
     return Tagged(context, m, Meta(NoMetaData(), ModuleMeta(NOMETA, bindings)))

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -82,29 +82,6 @@ function reflect(@nospecialize(sigtypes::Tuple), world::UInt = typemax(UInt))
     return Reflection(S, method, static_params, code_info)
 end
 
-#=== IR Repair ===#
-
-# TODO: update this
-function fix_labels_and_gotos!(code::Vector)
-    changes = Dict{Int,Int}()
-    for (i, stmnt) in enumerate(code)
-        if isa(stmnt, LabelNode)
-            code[i] = LabelNode(i)
-            changes[stmnt.label] = i
-        end
-    end
-    for (i, stmnt) in enumerate(code)
-        if isa(stmnt, GotoNode)
-            code[i] = GotoNode(get(changes, stmnt.label, stmnt.label))
-        elseif Base.Meta.isexpr(stmnt, :enter)
-            stmnt.args[1] = get(changes, stmnt.args[1], stmnt.args[1])
-        elseif Base.Meta.isexpr(stmnt, :gotoifnot)
-            stmnt.args[2] = get(changes, stmnt.args[2], stmnt.args[2])
-        end
-    end
-    return code
-end
-
 #################
 # Miscellaneous #
 #################

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -469,6 +469,12 @@ dispatchtupletest(::Type{T}) where {T} = Base.isdispatchtuple(Tuple{T}) ? T : An
 
 ############################################################################################
 
+@context TagConditionalCtx
+ctx = withtagfor(TagConditionalCtx(), 1)
+@test overdub(ctx, x -> x ? 1 : 2, tag(true, ctx)) === 1
+
+############################################################################################
+
 #= TODO: The rest of the tests below should be restored for the metadata tagging system
 
 @context NestedCtx


### PR DESCRIPTION
This seems to do what I want and passes the added test, but also seems to miscompile this weird case:

```julia
using Cassette

Cassette.@context Ctx

# Cassette.execute(::Ctx, ::typeof(println), args...) = println(args...)
# Cassette.prehook(::Ctx, ::typeof(>), args...) = println("called >", args)
# Cassette.posthook(::Ctx, output, ::typeof(>), args...) = println(">", args, " === ", output)

function f(neg::Bool)
    i = 1
    while i > neg
        # println(i)
        i -= 1
    end
    if neg end
    return i
end

Cassette.recurse(Cassette.withtagfor(Ctx(), 1), f, false)
```

When overdubbed in a tagged context, the while loop never terminates, though `i` continues to decrement and `i > neg` still gets called every iteration (uncomment the commented lines to see that in action). This would normally point to there being a problem with `GotoNode`/`gotoifnot` labels, however, the lowered IR seems correct to my naive eyes:

```julia
julia> @code_lowered(Cassette.recurse(Cassette.withtagfor(Ctx(), 1), f, false))
CodeInfo(
6  1 ─      #self# = (Core.getfield)(##recurse_arguments#369, 1)                                                  │
   │        neg = (Core.getfield)(##recurse_arguments#369, 2)                                                     │
   └──      i = 1                                                                                                 │
7  2 ┄ %4 = (Cassette.overdub)(##recurse_context#368, Main.:>, i, neg)                                            │
   │   %5 = (Cassette.untag)(%4, ##recurse_context#368)                                                           │
   └──      goto #5 if not %5                                                                                     │
9  3 ─      i = (Cassette.overdub)(##recurse_context#368, Main.:-, i, 1)                                          │
   └──      goto #2                                                                                               │
11 4 ─ %9 = (Cassette.untag)(neg, ##recurse_context#368)                                                          │
   5 ─      goto #6 if not %9                                                                                     │
12 6 ─      return i                                                                                              │
)
```

Checking the post-inference, pre-optimizer form of this IR:

```julia
julia> code_typed(Cassette.recurse, map(Core.Typeof, (Cassette.withtagfor(Ctx(), 1), f, false)); optimize = false)
1-element Array{Any,1}:
 CodeInfo(
6  1 ─      (#self# = (Core.getfield)(##recurse_arguments#369, 1))::Core.Compiler.Const(f, false)
   │        (neg = (Core.getfield)(##recurse_arguments#369, 2))::Bool       │
   └──      (i = 1)::Core.Compiler.Const(1, false)                          │
7  2 ┄ %4 = (Cassette.overdub)(##recurse_context#368, Main.:>, i, neg)::Bool│
   │   %5 = (Cassette.untag)(%4, ##recurse_context#368)::Bool               │
   └──      goto #5 if not %5                                               │
9  3 ─      (i = (Cassette.overdub)(##recurse_context#368, Main.:-, i, 1))::Int64
   └──      goto #2                                                         │
11 4 ─ %9 = Core.Compiler.Const(:((Cassette.untag)(neg, ##recurse_context#368)), false)::Union{}
   5 ─      %9::Union{}                                                     │
12 └──      Core.Compiler.Const(:(return i), false)::Union{}                │
) => Union{}
```