### PR TITLE
get rid of recurse/overdub cycle in favor of only overdub

### DIFF
--- a/src/context.jl
+++ b/src/context.jl
@@ -87,14 +87,3 @@ function withtagfor(context::Context, f)
 end
 
 nametype(::Type{<:Context{N}}) where {N} = N
-
-##############
-# `Fallback` #
-##############
-
-struct Fallback{F,C<:Context}
-    func::F
-    context::C
-end
-
-(f::Fallback)(args...) = error("Cassette.Fallback($(p.func), $(p.context)) can only be executed in a context with the same type as $(p.context)")

--- a/src/tagged.jl
+++ b/src/tagged.jl
@@ -69,8 +69,9 @@ end
 
 # TODO: For fast methods (~ns), this fetch can cost drastically more than the primal method
 # invocation. We easily have the module at compile time, but we don't have access to the
-# actual context object. This `@pure` is vtjnash-approved. It should allow the compiler to
-# optimize away the fetch once we have support for it, e.g. loop invariant code motion.
+# actual context object (just the type). This `@pure` is vtjnash-approved. It should allow
+# the compiler to optimize away the fetch once we have support for it, e.g. loop invariant
+# code motion.
 Base.@pure @noinline function fetch_tagged_module(context::Context, m::Module)
     bindings = get!(() -> BindingMetaDict(), context.bindings, m)
     return Tagged(context, m, Meta(NoMetaData(), ModuleMeta(NOMETA, bindings)))


### PR DESCRIPTION
supercedes #62 
fixes #59 (@Keno)
fixes #61 

In my ongoing quest to increase user confusion, this PR removes the current `Cassette.overdub` and changes the name of `Cassette.recurse` to `Cassette.overdub`. This new `overdub` function performs a similar operation to the old `recurse`, but now manually inlines the body of the old `overdub` function instead of calling such a function.

This is a fairly disruptive change this close to Cassette's impending initial release, but it's worth it. This approach has drastically less reliance on splatting optimizations than the current approach, and additionally ensures there are (mostly) no more unspoofed recursion cycles left to trigger inferences limiting heuristic. As a result, many things are inferring now that weren't before (including the examples from #59). As a nice little side effect, we get to cut down our API by a function.

The tradeoff is that this approach requires more IR-munging than the old approach. Lucky, I was able to move most of the finnicky stuff to a reusable utility function (`insert_ir_elements!`).

All tests here pass locally. I'm not sure if CI will pass immediately, though, since this requires JuliaLang/julia#28279 which was just merged.

Oh, and this removes `Fallback` (which as I've said before, was kind of just sitting around as an idea, but I don't think it's very useful here).