### PR TITLE
change posthook to return overdubbed invocation output so that it can postprocess immutable outputs

### DIFF
--- a/docs/src/overdub.md
+++ b/docs/src/overdub.md
@@ -45,31 +45,31 @@ And now let's look at lowered IR for the call to `overdub(Ctx(), /, 1, 2)`
 ```julia
 julia> @code_lowered Cassette.overdub(Ctx(), /, 1, 2)
 CodeInfo(
-59 1 ─       #self# = (Core.getfield)(##overdub_arguments#369, 1)
-   │         x = (Core.getfield)(##overdub_arguments#369, 2)
-   │         y = (Core.getfield)(##overdub_arguments#369, 3)
-   │         (Cassette.prehook)(##overdub_context#368, Base.float, x)
-   │         ##overdub_tmp#370 = (Cassette.execute)(##overdub_context#368, Base.float, x)
-   │   %6  = ##overdub_tmp#370 isa Cassette.OverdubInstead
-   └──       goto #3 if not %6
-   2 ─       ##overdub_tmp#370 = (Cassette.overdub)(##overdub_context#368, Base.float, x)
-   3 ─       (Cassette.posthook)(##overdub_context#368, ##overdub_tmp#370, Base.float, x)
-   │   %10 = ##overdub_tmp#370
-   │         (Cassette.prehook)(##overdub_context#368, Base.float, y)
-   │         ##overdub_tmp#370 = (Cassette.execute)(##overdub_context#368, Base.float, y)
-   │   %13 = ##overdub_tmp#370 isa Cassette.OverdubInstead
-   └──       goto #5 if not %13
-   4 ─       ##overdub_tmp#370 = (Cassette.overdub)(##overdub_context#368, Base.float, y)
-   5 ─       (Cassette.posthook)(##overdub_context#368, ##overdub_tmp#370, Base.float, y)
-   │   %17 = ##overdub_tmp#370
-   │         (Cassette.prehook)(##overdub_context#368, Base.:/, %10, %17)
-   │         ##overdub_tmp#370 = (Cassette.execute)(##overdub_context#368, Base.:/, %10, %17)
-   │   %20 = ##overdub_tmp#370 isa Cassette.OverdubInstead
-   └──       goto #7 if not %20
-   6 ─       ##overdub_tmp#370 = (Cassette.overdub)(##overdub_context#368, Base.:/, %10, %17)
-   7 ─       (Cassette.posthook)(##overdub_context#368, ##overdub_tmp#370, Base.:/, %10, %17)
-   │   %24 = ##overdub_tmp#370
-   └──       return %24
+59 1 ─       #self# = (Core.getfield)(##overdub_arguments#369, 1)                                                 │
+   │         x = (Core.getfield)(##overdub_arguments#369, 2)                                                      │
+   │         y = (Core.getfield)(##overdub_arguments#369, 3)                                                      │
+   │         (Cassette.prehook)(##overdub_context#368, Base.float, x)                                             │
+   │         ##overdub_tmp#370 = (Cassette.execute)(##overdub_context#368, Base.float, x)                         │
+   │   %6  = ##overdub_tmp#370 isa Cassette.OverdubInstead                                                        │
+   └──       goto #3 if not %6                                                                                    │
+   2 ─       ##overdub_tmp#370 = (Cassette.overdub)(##overdub_context#368, Base.float, x)                         │
+   └──       ##overdub_tmp#370 = (Cassette.posthook)(##overdub_context#368, ##overdub_tmp#370, Base.float, x)     │
+   3 ─ %10 = ##overdub_tmp#370                                                                                    │
+   │         (Cassette.prehook)(##overdub_context#368, Base.float, y)                                             │
+   │         ##overdub_tmp#370 = (Cassette.execute)(##overdub_context#368, Base.float, y)                         │
+   │   %13 = ##overdub_tmp#370 isa Cassette.OverdubInstead                                                        │
+   └──       goto #5 if not %13                                                                                   │
+   4 ─       ##overdub_tmp#370 = (Cassette.overdub)(##overdub_context#368, Base.float, y)                         │
+   └──       ##overdub_tmp#370 = (Cassette.posthook)(##overdub_context#368, ##overdub_tmp#370, Base.float, y)     │
+   5 ─ %17 = ##overdub_tmp#370                                                                                    │
+   │         (Cassette.prehook)(##overdub_context#368, Base.:/, %10, %17)                                         │
+   │         ##overdub_tmp#370 = (Cassette.execute)(##overdub_context#368, Base.:/, %10, %17)                     │
+   │   %20 = ##overdub_tmp#370 isa Cassette.OverdubInstead                                                        │
+   └──       goto #7 if not %20                                                                                   │
+   6 ─       ##overdub_tmp#370 = (Cassette.overdub)(##overdub_context#368, Base.:/, %10, %17)                     │
+   └──       ##overdub_tmp#370 = (Cassette.posthook)(##overdub_context#368, ##overdub_tmp#370, Base.:/, %10, %17) │
+   7 ─ %24 = ##overdub_tmp#370                                                                                    │
+   └──       return %24                                                                                           │
 )
 ```
 
@@ -84,7 +84,7 @@ begin
     Cassette.prehook(context, f, args...)
     tmp = Cassette.execute(context, f, args...)
     tmp = isa(tmp, Cassette.OverdubInstead) ? overdub(context, f, args...) : tmp
-    Cassette.posthook(context, tmp, f, args...)
+    tmp = Cassette.posthook(context, tmp, f, args...)
     tmp
 end
 ```

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,7 +43,7 @@ end
 
 @context HookCtx
 Cassette.prehook(ctx::HookCtx, f, args...) = push!(ctx.metadata[1], (f, args))
-Cassette.posthook(ctx::HookCtx, out, f, args...) = push!(ctx.metadata[2], (f, args))
+Cassette.posthook(ctx::HookCtx, out, f, args...) = (push!(ctx.metadata[2], (f, args)); out)
 
 ctx = HookCtx(metadata=(Any[], Any[]))
 @overdub(ctx, 1 + 1 * 1)
@@ -641,3 +641,10 @@ x = rand()
 @test D(x -> (x + 2) * (3 + x), x) === 2x + 5
 @test D(x -> CrazyPropModule.crazy_sum_mul([x], [x]), x) === (x + x)
 @test D(x -> CrazyPropModule.crazy_sum_mul([x, 2], [3, x]), x) === 2x + 5
+
+############################################################################################
+
+@context CrazyCompilerBugCtx
+
+# This is just testing to make sure we're not hitting a known miscompile case TODO: xref Base issue
+@test overdub(CrazyCompilerBugCtx(metadata=1), Broadcast._newindexer, (Base.OneTo(10),)) === ((true,), (1,))


### PR DESCRIPTION
So, I'd like this API change to be in the initial Cassette release, but it unfortunately triggers a pretty crazy miscompile which can be repro'd by running the given test.