### PR TITLE
fix overdubbing for invoke

### DIFF
--- a/src/context.jl
+++ b/src/context.jl
@@ -466,4 +466,5 @@ Note that unlike `execute`, `fallback`, etc., this function is not intended to b
 See also:  [`overdub`](@ref), [`fallback`](@ref), [`execute`](@ref)
 """
 @inline canoverdub(ctx::Context, f, ::Vararg{Any}) = !isa(untag(f, ctx), Core.Builtin)
-@inline canoverdub(ctx::Context, ::typeof(Core._apply), f, ::Vararg{Any}) = canoverdub(ctx, f)
+@inline canoverdub(ctx::Context, ::typeof(Core._apply), f, args...) = canoverdub(ctx, f, apply_args(ctx, args...)...)
+@inline canoverdub(ctx::Context, ::typeof(Core.invoke), f, args...) = canoverdub(ctx, f, args...)

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -6,10 +6,16 @@ inferred_retval(f, sig) = code_typed(f, sig)[1].first.code[end].args[1]
 
 @context CanOverdubTestCtx
 ctx = CanOverdubTestCtx()
-# test that the result value of is inferred exactly for `T <: Core.Builtin`
+# test that the result value of `canoverdub` is inferred exactly for `T <: Core.Builtin`
 for T in subtypes(Core.Builtin)
     if !(T <: typeof(Core._apply))
         @test !inferred_retval(canoverdub, (typeof(ctx), T))
         @test !inferred_retval(canoverdub, (typeof(ctx), typeof(Core._apply), T))
+        @test !inferred_retval(canoverdub, (typeof(ctx), typeof(Core.invoke), T))
     end
 end
+
+@test canoverdub(ctx, hypot, 1, 2)
+@test canoverdub(ctx, Core.invoke, hypot, Tuple{Int,Int}, 1, 2)
+@test canoverdub(ctx, Core._apply, hypot, (1, 2))
+@test canoverdub(ctx, Core._apply, Core.invoke, (hypot, Tuple{Int,Int}, 1, 2))


### PR DESCRIPTION
Previously, Cassette did not correctly overdub `invoke` calls; it treated them as primitives. This PR fixes that.