### PR TITLE
Contexts can be declared twice without error

### DIFF
--- a/src/context.jl
+++ b/src/context.jl
@@ -220,8 +220,10 @@ See also: [`Context`](@ref)
 """
 macro context(Ctx)
     @assert isa(Ctx, Symbol) "context name must be a Symbol"
-    CtxName = gensym(string(Ctx, "Name"))
-    TaggedCtx = gensym(string(Ctx, "Tagged"))
+    
+    # No gensym on the name, so the same name returns the same Context type.
+    CtxName = Symbol("##$(Ctx)#Name")
+    TaggedCtx = Symbol("##$(Ctx)#Tagged")
     Typ = :(Core.Typeof)
     return esc(quote
         struct $CtxName <: $Cassette.AbstractContextName end

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -19,3 +19,14 @@ end
 @test canoverdub(ctx, Core.invoke, hypot, Tuple{Int,Int}, 1, 2)
 @test canoverdub(ctx, Core._apply, hypot, (1, 2))
 @test canoverdub(ctx, Core._apply, Core.invoke, (hypot, Tuple{Int,Int}, 1, 2))
+
+
+###########
+
+# Declaring a `@context` with the same name twice, should be a No-Op, not an error
+# Code below will throw an error if this is not true
+
+@context FooBar
+@context FooBar
+
+


### PR DESCRIPTION
This is to improve the workflow of being able to just copy paste, edit, copy paste, into the REPL.

It matchs the normal julia behavour of being allowed to redeclare constant values, and redefine types so long as the definition does not change.