### PR TITLE
Refactor to reduce IR bloat for nested overdubbing, plus other stuff for Zygote

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -16,7 +16,7 @@ makedocs(modules=[Cassette],
 
 deploydocs(repo = "github.com/jrevels/Cassette.jl.git",
            osname = "linux",
-           julia = "0.7",
+           julia = "1.0",
            target = "build",
            deps = nothing,
            make = nothing)

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -7,6 +7,7 @@ CurrentModule = Cassette
 ```@docs
 Cassette.Context
 Cassette.similarcontext
+Cassette.disablehooks
 Cassette.enabletagging
 Cassette.hastagging
 Cassette.@context
@@ -15,6 +16,7 @@ Cassette.@context
 ```@docs
 Cassette.overdub
 Cassette.@overdub
+Cassette.recurse
 Cassette.prehook
 Cassette.posthook
 Cassette.execute
@@ -26,6 +28,10 @@ Cassette.canrecurse
 Cassette.@pass
 Cassette.replace_match!
 Cassette.insert_statements!
+Cassette.is_ir_element
+Cassette.OVERDUB_CONTEXT_NAME
+Cassette.OVERDUB_ARGUMENTS_NAME
+Cassette.Reflection
 ```
 
 ```@docs

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -19,7 +19,6 @@ Cassette.@overdub
 Cassette.recurse
 Cassette.prehook
 Cassette.posthook
-Cassette.execute
 Cassette.fallback
 Cassette.canrecurse
 ```

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -19,7 +19,7 @@ Cassette.prehook
 Cassette.posthook
 Cassette.execute
 Cassette.fallback
-Cassette.canoverdub
+Cassette.canrecurse
 ```
 
 ```@docs

--- a/docs/src/contextualpass.md
+++ b/docs/src/contextualpass.md
@@ -152,8 +152,7 @@ accomplish the above:
 - At the beginning of each method body, insert something like `_callback_ = context.metadata`
 - Change every method invocation of the form `f(args...)` to `f(_callback_, args...)`.
 - Change every return statement of the form `return x` to `return (x, _callback_)`
-- Ensure the output of every method invocation is properly destructured into the original
-assignment slot/SSAValue and the `_callback_` slot.
+- Ensure the output of every method invocation is properly destructured into the original assignment slot/SSAValue and the `_callback_` slot.
 
 Okay! Now that we have a high-level description of our pass, let's look at the code that implements
 it. **I highly recommend reading the documentation for [`@pass`](@ref) and

--- a/docs/src/disclaimers.md
+++ b/docs/src/disclaimers.md
@@ -13,14 +13,6 @@ well as a loaded foot-gun. Here are some things one should know before using Cas
     multiple Cassette contexts. Please file issues on the Cassette and/or Julia issue
     tracker where appropriate.
 
-- For now, **each individual version of Cassette can technically only support a single
-    specific version of Julia at a time**; differing by even a patch version could
-    (theoretically) break Cassette entirely. This is because Cassette interacts closely with
-    Julia internals that traditionally have license to change between patch versions. In the
-    future, the planned solution for this issue is for Julia itself to perform
-    reverse-dependency testing against Cassette's tests, such that breaking changes to Julia
-    compiler are discovered and fixed immediately.
-
 - **The performance of Cassette's implementation of the contextual tagging system heavily
     depends on compiler improvements planned for the Julia `1.x` release cycle.** In theory,
     given these compiler improvements, the contextual tagging system could achieve

--- a/docs/src/overdub.md
+++ b/docs/src/overdub.md
@@ -24,9 +24,9 @@ to see what's actually going on.
 
 First, we define a new [`Context`](@ref) type alias called `Ctx` via the [`@context`](@ref)
 macro. In practical usage, one normally defines one or more contexts specific to one's
-application of Cassette. Here, we just made a dummy one for illustrative purposes. Context
-instances are central to Cassette's function, but are relatively simple to construct and
-understand. I recommend skimming the [`Context`](@ref) docstring before moving forward.
+application of Cassette. Here, we just made a dummy one for illustrative purposes. Contexts
+are relatively simple to construct and understand, and are of central importance to Cassette's
+operation. I recommend skimming the [`Context`](@ref) docstring before moving forward.
 
 Next, we "overdubbed" a call to `1/2` w.r.t. `Ctx()` using the [`overdub`](@ref) function. To
 get a sense of what that means, let's look at the lowered IR for the original call:
@@ -75,16 +75,16 @@ statements similar to the following:
 begin
     Cassette.prehook(context, f, args...)
     %n = Cassette.overdub(context, f, args...)
-    Cassette.posthook(context, tmp, f, args...)
+    Cassette.posthook(context, %n, f, args...)
     %n
 end
 ```
 
 It is here that we experience our first bit of overdubbing magic: for every method call
-in the overdubbed trace, we obtain a bunch of extra overloading points that we didn't
+in the overdubbed trace, we obtain several extra points of overloadability that we didn't
 have before! In the [following section on contextual dispatch](contextualdispatch.md), we'll
-explore how [`prehook`](@ref), [`posthook`](@ref), and more can all be overloaded to add new
-contextual behaviors to overdubbed programs.
+explore how [`prehook`](@ref), [`posthook`](@ref), and even [`overdub`](@ref) itself can be
+overloaded to add new contextual behaviors to overdubbed programs.
 
 In the meantime, we should clarify how `overdub` is achieving this feat. Let's start by
 examining a "pseudo-implementation" of `overdub`:
@@ -101,7 +101,7 @@ examining a "pseudo-implementation" of `overdub`:
 end
 ```
 
-As you can see, `overdub` is a `@generated` function, and thus returns its own method body
+As you can see, `overdub` is a `@generated` function, and thus returns a method body
 computed from the run-time types of its inputs. To actually compute this method body,
 `overdub` is doing something quite special.
 

--- a/src/Cassette.jl
+++ b/src/Cassette.jl
@@ -8,4 +8,6 @@ include("tagging.jl")
 include("overdub.jl")
 include("deprecations.jl")
 
+const NO_PASS = @pass (_, r) -> r.code_info
+
 end # module

--- a/src/Cassette.jl
+++ b/src/Cassette.jl
@@ -6,5 +6,6 @@ include("context.jl")
 include("pass.jl")
 include("tagging.jl")
 include("overdub.jl")
+include("deprecations.jl")
 
 end # module

--- a/src/context.jl
+++ b/src/context.jl
@@ -4,10 +4,6 @@
 
 abstract type AbstractPass end
 
-struct NoPass <: AbstractPass end
-
-(::Type{NoPass})(::Any, ::Any, code_info) = code_info
-
 #########
 # `Tag` #
 #########
@@ -118,7 +114,7 @@ const ContextTagged{T<:Tag,N<:AbstractContextName} = Context{N,<:Any,T}
 const ContextWithPass{P<:AbstractPass,N<:AbstractContextName} = Context{N,<:Any,<:Union{Nothing,Tag},P}
 const ContextWithHookToggle{H<:Union{Nothing,DisableHooks},N<:AbstractContextName} = Context{N,<:Any,<:Union{Nothing,Tag},<:AbstractPass,<:Union{Nothing,BindingMetaDictCache},H}
 
-function Context(name::AbstractContextName; metadata = nothing, pass::AbstractPass = NoPass())
+function Context(name::AbstractContextName; metadata = nothing, pass::AbstractPass = NO_PASS)
     return Context(name, metadata, nothing, pass, nothing, nothing)
 end
 

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,0 +1,17 @@
+Sorry_OverdubInstead_Is_Deprecated() = error("Usage of `OverdubInstead` should be replaced by `Cassette.recurse`; see `Cassette.recurse` for details.")
+
+Base.@deprecate_binding(OverdubInstead, Sorry_OverdubInstead_Is_Deprecated, false,
+string("; the `overdub` <--> `execute` cycle has been removed from Cassette, and",
+       " usage of `OverdubInstead` has been replaced with `Cassette.recurse`;",
+       " see `Cassette.recurse` for details."))
+
+struct Sorry_Execute_Is_Deprecated end
+
+Base.@deprecate_binding(execute, Sorry_Execute_Is_Deprecated, false,
+string("; the `overdub` <--> `execute` cycle has been removed from Cassette. In",
+       " most cases, `execute` calls can now be replaced with `overdub`; in",
+       " general, however, users may need to do some extra refactoring to",
+       " properly migrate to the new overdubbing model. Feel free to open a",
+       " Cassette issue for help with migration."))
+
+Base.@deprecate(canoverdub(args...), canrecurse(args...))

--- a/src/overdub.jl
+++ b/src/overdub.jl
@@ -96,6 +96,7 @@ function overdub_pass!(reflection::Reflection,
 
     if !iskwfunc
         code_info = passtype(context_type)(context_type, reflection)
+        isa(code_info, Expr) && return code_info
     end
 
     #=== munge the code into a valid form for `overdub_generator` ===#
@@ -435,7 +436,8 @@ function __overdub_generator__(self, context_type, args::Tuple)
                 untagged_args = ((untagtype(args[i], context_type) for i in 1:nfields(args))...,)
                 reflection = reflect(untagged_args)
                 if isa(reflection, Reflection)
-                    overdub_pass!(reflection, context_type, is_invoke)
+                    result = overdub_pass!(reflection, context_type, is_invoke)
+                    isa(result, Expr) && return result
                     return reflection.code_info
                 end
             catch err

--- a/src/overdub.jl
+++ b/src/overdub.jl
@@ -95,7 +95,7 @@ function overdub_pass!(reflection::Reflection,
     #=== execute user-provided pass (is a no-op by default) ===#
 
     if !iskwfunc
-        code_info = passtype(context_type)(context_type, signature, code_info)
+        code_info = passtype(context_type)(context_type, reflection)
     end
 
     #=== munge the code into a valid form for `overdub_generator` ===#

--- a/src/overdub.jl
+++ b/src/overdub.jl
@@ -86,7 +86,7 @@ method definition.
 This binding can be used to manually reference/destructure `overdub` arguments
 within `Expr` thunks emitted by user-provided passes.
 
-See also: [`OVERDUB_ARGUMENTS_NAME`](@ref), [`pass`](@ref), [`overdub`](@ref)
+See also: [`OVERDUB_ARGUMENTS_NAME`](@ref), [`@pass`](@ref), [`overdub`](@ref)
 """
 const OVERDUB_CONTEXT_NAME = gensym("overdub_context")
 
@@ -99,7 +99,7 @@ The variable name bound to `overdub`'s tuple of non-`Context` arguments in its
 This binding can be used to manually reference/destructure `overdub` arguments
 within `Expr` thunks emitted by user-provided passes.
 
-See also: [`OVERDUB_CONTEXT_NAME`](@ref), [`pass`](@ref), [`overdub`](@ref)
+See also: [`OVERDUB_CONTEXT_NAME`](@ref), [`@pass`](@ref), [`overdub`](@ref)
 """
 const OVERDUB_ARGUMENTS_NAME = gensym("overdub_arguments")
 

--- a/src/overdub.jl
+++ b/src/overdub.jl
@@ -486,8 +486,6 @@ function overdub_definition(line, file)
     end
 end
 
-@eval $(overdub_definition(@__LINE__, @__FILE__))
-
 @doc(
 """
 ```

--- a/src/pass.jl
+++ b/src/pass.jl
@@ -53,7 +53,7 @@ macro pass(transform)
     return esc(quote
         import Cassette.__overdub_generator__
         struct $Pass <: $Cassette.AbstractPass end
-        (::Type{$Pass})(ctxtype, signature, codeinfo) = $transform(ctxtype, signature, codeinfo)
+        (::Type{$Pass})(ctxtype, reflection) = $transform(ctxtype, reflection)
         Core.eval($__module__, $Cassette.overdub_definition($line, $file))
         $Pass()
     end)

--- a/test/misctests.jl
+++ b/test/misctests.jl
@@ -184,6 +184,26 @@ println("done (took ", time() - before_time, " seconds)")
 
 #############################################################################################
 
+print("   running PassFallbackCtx test...")
+
+before_time = time()
+
+@context PassFallbackCtx
+fallbackpass = @pass (ctx, ref) -> begin
+    if ref.signature <: Tuple{typeof(sin),Any}
+        return :(cos($(Cassette.OVERDUB_ARGUMENTS_NAME)[2]))
+    end
+    return ref.code_info
+end
+x = rand(30)
+sin_kernel(i) = i > 0.5 ? sin(i) : i
+y = @inferred(overdub(PassFallbackCtx(pass=fallbackpass), sum, sin_kernel, x))
+@test sum(i -> i > 0.5 ? cos(i) : i, x) === y
+
+println("done (took ", time() - before_time, " seconds)")
+
+#############################################################################################
+
 print("   running WorldCtx test...")
 
 before_time = time()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,8 @@
 using Test, Cassette, LinearAlgebra
-using Cassette: @context, @pass, @overdub, overdub, hasmetadata, metadata, hasmetameta,
-                metameta, untag, tag, enabletagging, untagtype, istagged, istaggedtype,
-                Tagged, fallback, canoverdub, similarcontext
+using Cassette: @context, @pass, @overdub, overdub, recurse, hasmetadata,
+                metadata, hasmetameta, metameta, untag, tag, enabletagging,
+                untagtype, istagged, istaggedtype, Tagged, fallback, canrecurse,
+                similarcontext, disablehooks
 
 println("running unit tests")
 @time @testset "unit tests" begin include("unittests.jl") end

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -1,25 +1,37 @@
 # TODO: this file is pretty sparse...
 
 using InteractiveUtils: subtypes
+using Core.Compiler: SSAValue, Const, GotoNode
 
-inferred_retval(f, sig) = code_typed(f, sig)[1].first.code[end].args[1]
+function const_bool_retval(f, sig)
+    ctyped = code_typed(f, sig)[1].first
+    retval = ctyped.code[end]
+    retval = isa(retval, GotoNode) ? ctyped.code[retval.label] : retval
+    retval = Meta.isexpr(retval, :return) ? retval.args[1] : retval
+    retval = isa(retval, SSAValue) ? ctyped.ssavaluetypes[retval.id] : retval
+    retval = isa(retval, Const) ? retval.val : retval
+    isa(retval, Bool) && return retval
+    error("did not infer constant boolean return value for ", f, sig)
+end
 
-@context CanOverdubTestCtx
-ctx = CanOverdubTestCtx()
-# test that the result value of `canoverdub` is inferred exactly for `T <: Core.Builtin`
+@context canrecurseTestCtx
+ctx = canrecurseTestCtx()
+# Test that the result value of `canrecurse` is inferred exactly for `T <: Core.Builtin`.
+# Note that these aren't necessarily valid full call signatures, this is just
+# testing that Cassette's `canrecurse` implementation has an inferrable
+# short-circuiting `Core.Builtin` check.
 for T in subtypes(Core.Builtin)
     if !(T <: typeof(Core._apply))
-        @test !inferred_retval(canoverdub, (typeof(ctx), T))
-        @test !inferred_retval(canoverdub, (typeof(ctx), typeof(Core._apply), T))
-        @test !inferred_retval(canoverdub, (typeof(ctx), typeof(Core.invoke), T))
+        @test !const_bool_retval(canrecurse, (typeof(ctx), T))
+        @test !const_bool_retval(canrecurse, (typeof(ctx), typeof(Core._apply), T))
+        @test !const_bool_retval(canrecurse, (typeof(ctx), typeof(Core.invoke), T))
     end
 end
 
-@test canoverdub(ctx, hypot, 1, 2)
-@test canoverdub(ctx, Core.invoke, hypot, Tuple{Int,Int}, 1, 2)
-@test canoverdub(ctx, Core._apply, hypot, (1, 2))
-@test canoverdub(ctx, Core._apply, Core.invoke, (hypot, Tuple{Int,Int}, 1, 2))
-
+@test canrecurse(ctx, hypot, 1, 2)
+@test canrecurse(ctx, Core.invoke, hypot, Tuple{Int,Int}, 1, 2)
+@test canrecurse(ctx, Core._apply, hypot, (1, 2))
+@test canrecurse(ctx, Core._apply, Core.invoke, (hypot, Tuple{Int,Int}, 1, 2))
 
 ###########
 
@@ -28,5 +40,3 @@ end
 
 @context FooBar
 @context FooBar
-
-


### PR DESCRIPTION
This PR implements a few changes requested by @MikeInnes to enable Zygote's Cassette-style transformation to replaced with actual Cassette:

1. Adds a `disablehooks` function to turn off `prehook`/`posthook` injection
2. Replace the usually constant-folded  `isa(..., OverdubInstead)` branch with direct recursion.
3. User passes are now provided with the full `Cassette.Reflection` argument, instead of just the signature and `CodeInfo`.
4. User passes can return `Expr` objects, which Cassette will essentially just emit as fallback thunks. I actually don't think this is totally necessary, but I think it will ease the transition for https://github.com/FluxML/Zygote.jl/pull/45.

Changes 1 and 2 allow users to configure their contexts such that lowered IR size (in statement count) doesn't increase exponentially for when nesting overdubs.

Note that changes 2 and 3 are fairly breaking, but the migration paths for each are pretty simple. For 2, most cases just involves switching `execute` to `overdub` and `overdub` to `recurse`. For 3, the provided `Reflection` object contains the `CodeInfo` and signature previously passed to user's transform function. After this is merged, feel free to ping me/open issues and I can help with migrating folks' Cassette usage/fixing any breakage that pops up.

Additionally, this PR implements better handling of `Core._apply` calls (probably should've factored that out into a separate PR, but got a bit carried way).

Barring any additional stuff as https://github.com/FluxML/Zygote.jl/pull/45 develops, this PR is essentially complete modulo documentation/tests. ~~I'll try to update those ASAP as any new changes are made.~~ Basically done for now.