### PR TITLE
Show stacktrace for errors in passes

### DIFF
--- a/src/overdub.jl
+++ b/src/overdub.jl
@@ -477,6 +477,7 @@ function __overdub_generator__(self, context_type, args::Tuple)
                 end
             catch err
                 errmsg = "ERROR COMPILING $args IN CONTEXT $(context_type): \n" * sprint(showerror, err)
+                errmsg *= "\n" .* repr("text/plain", stacktrace(catch_backtrace()))
                 return quote
                     error($errmsg)
                 end


### PR DESCRIPTION
This is a bit of a hacky way todo it, but it is readable.
This informations is sometimes very  useful for debugging when you screw up writing a  pass.

Othertimes it is not