### PR TITLE
Revert "Declaring a pass twice should have no effect (#106)"

### DIFF
--- a/src/pass.jl
+++ b/src/pass.jl
@@ -53,7 +53,7 @@ computed IR results, instead of recomputing results every time).
 See also: [`Context`](@ref), [`overdub`](@ref)
 """
 macro pass(transform)
-    Pass = Symbol("##PassType#$transform")
+    Pass = gensym("PassType")
     line = Expr(:quote, __source__.line)
     file = Expr(:quote, __source__.file)
     return esc(quote

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -37,10 +37,6 @@ end
 
 # Declaring a `@context` with the same name twice, should be a No-Op, not an error
 # Code below will throw an error if this is not true
-@context FooBar
-@context FooBar
 
-# Declaring a `@pass` with the same name twice, should be a No-Op, not an error
-# Code below will throw an error if this is not true
-@pass BarFoo
-@pass BarFoo
+@context FooBar
+@context FooBar


### PR DESCRIPTION
This reverts commit 50826bd4040b7dd8f09d3962f765a3080f47c633.

cc @oxinabox I didn't review #106 closely enough, my bad - the argument to `@pass` isn't the "pass name"; it's an expression that expands to the function (either via direct implementation, or by name) that implements the pass. For example `Cassette.@pass (ctx, ref) -> ref.code_info` is a valid way to instantiate a no-op pass; so is `(f(ctx, ref) = ref.code_info); Cassette.@pass f`. Additionally the test added there actually passes without the PR

