### PR TITLE
fix method overwrite warning (replace #115, fix #113)

### DIFF
--- a/src/overdub.jl
+++ b/src/overdub.jl
@@ -502,8 +502,21 @@ function recurse end
 
 recurse(ctx::Context, ::typeof(Core._apply), f, args...) = Core._apply(recurse, (ctx, f), args...)
 
+function delete_overdub_or_recurse_method(overdub_or_recurse)
+    ms = Base.methods(overdub_or_recurse, (Context, Any)).ms
+    for m in ms
+        if m.sig == Tuple{typeof(overdub_or_recurse),Context,Vararg{Any}}
+            Base.delete_method(m)
+            return nothing
+        end
+    end
+    return nothing
+end
+
 function overdub_definition(line, file)
     return quote
+        $Cassette.delete_overdub_or_recurse_method($Cassette.overdub)
+        $Cassette.delete_overdub_or_recurse_method($Cassette.recurse)
         function $Cassette.overdub($OVERDUB_CONTEXT_NAME::$Cassette.Context, $OVERDUB_ARGUMENTS_NAME...)
             $(Expr(:meta, :generated_only))
             $(Expr(:meta,

--- a/src/overdub.jl
+++ b/src/overdub.jl
@@ -471,7 +471,7 @@ const OVERDUB_FALLBACK = begin
 end
 
 # `args` is `(typeof(original_function), map(typeof, original_args_tuple)...)`
-function __overdub_generator__(self, context_type, args::Tuple)
+function __overdub_generator__(pass_type, self, context_type, args::Tuple)
     if nfields(args) > 0
         is_builtin = args[1] <: Core.Builtin
         is_invoke = args[1] === typeof(Core.invoke)
@@ -502,9 +502,9 @@ function recurse end
 
 recurse(ctx::Context, ::typeof(Core._apply), f, args...) = Core._apply(recurse, (ctx, f), args...)
 
-function overdub_definition(line, file)
+function overdub_definition(line, file, pass)
     return quote
-        function $Cassette.overdub($OVERDUB_CONTEXT_NAME::$Cassette.Context, $OVERDUB_ARGUMENTS_NAME...)
+        function $Cassette.overdub($OVERDUB_CONTEXT_NAME::$Cassette.ContextWithPass{P}, $OVERDUB_ARGUMENTS_NAME...) where {P<:$pass}
             $(Expr(:meta, :generated_only))
             $(Expr(:meta,
                    :generated,
@@ -512,12 +512,12 @@ function overdub_definition(line, file)
                         Core.GeneratedFunctionStub,
                         :__overdub_generator__,
                         Any[:overdub, OVERDUB_CONTEXT_NAME, OVERDUB_ARGUMENTS_NAME],
-                        Any[],
+                        Any[:pass],
                         line,
                         QuoteNode(Symbol(file)),
                         true)))
         end
-        function $Cassette.recurse($OVERDUB_CONTEXT_NAME::$Cassette.Context, $OVERDUB_ARGUMENTS_NAME...)
+        function $Cassette.recurse($OVERDUB_CONTEXT_NAME::$Cassette.ContextWithPass{P}, $OVERDUB_ARGUMENTS_NAME...) where {P<:$pass}
             $(Expr(:meta, :generated_only))
             $(Expr(:meta,
                    :generated,
@@ -525,7 +525,7 @@ function overdub_definition(line, file)
                         Core.GeneratedFunctionStub,
                         :__overdub_generator__,
                         Any[:recurse, OVERDUB_CONTEXT_NAME, OVERDUB_ARGUMENTS_NAME],
-                        Any[],
+                        Any[:pass],
                         line,
                         QuoteNode(Symbol(file)),
                         true)))

--- a/src/overdub.jl
+++ b/src/overdub.jl
@@ -471,7 +471,7 @@ const OVERDUB_FALLBACK = begin
 end
 
 # `args` is `(typeof(original_function), map(typeof, original_args_tuple)...)`
-function __overdub_generator__(pass_type, self, context_type, args::Tuple)
+function __overdub_generator__(self, context_type, args::Tuple)
     if nfields(args) > 0
         is_builtin = args[1] <: Core.Builtin
         is_invoke = args[1] === typeof(Core.invoke)
@@ -502,9 +502,9 @@ function recurse end
 
 recurse(ctx::Context, ::typeof(Core._apply), f, args...) = Core._apply(recurse, (ctx, f), args...)
 
-function overdub_definition(line, file, pass)
+function overdub_definition(line, file)
     return quote
-        function $Cassette.overdub($OVERDUB_CONTEXT_NAME::$Cassette.ContextWithPass{P}, $OVERDUB_ARGUMENTS_NAME...) where {P<:$pass}
+        function $Cassette.overdub($OVERDUB_CONTEXT_NAME::$Cassette.Context, $OVERDUB_ARGUMENTS_NAME...)
             $(Expr(:meta, :generated_only))
             $(Expr(:meta,
                    :generated,
@@ -512,12 +512,12 @@ function overdub_definition(line, file, pass)
                         Core.GeneratedFunctionStub,
                         :__overdub_generator__,
                         Any[:overdub, OVERDUB_CONTEXT_NAME, OVERDUB_ARGUMENTS_NAME],
-                        Any[:pass],
+                        Any[],
                         line,
                         QuoteNode(Symbol(file)),
                         true)))
         end
-        function $Cassette.recurse($OVERDUB_CONTEXT_NAME::$Cassette.ContextWithPass{P}, $OVERDUB_ARGUMENTS_NAME...) where {P<:$pass}
+        function $Cassette.recurse($OVERDUB_CONTEXT_NAME::$Cassette.Context, $OVERDUB_ARGUMENTS_NAME...)
             $(Expr(:meta, :generated_only))
             $(Expr(:meta,
                    :generated,
@@ -525,7 +525,7 @@ function overdub_definition(line, file, pass)
                         Core.GeneratedFunctionStub,
                         :__overdub_generator__,
                         Any[:recurse, OVERDUB_CONTEXT_NAME, OVERDUB_ARGUMENTS_NAME],
-                        Any[:pass],
+                        Any[],
                         line,
                         QuoteNode(Symbol(file)),
                         true)))

--- a/src/pass.jl
+++ b/src/pass.jl
@@ -60,7 +60,7 @@ macro pass(transform)
         import Cassette.__overdub_generator__
         struct $Pass <: $Cassette.AbstractPass end
         (::Type{$Pass})(ctxtype, reflection) = $transform(ctxtype, reflection)
-        Core.eval($__module__, $Cassette.overdub_definition($line, $file))
+        Core.eval($__module__, $Cassette.overdub_definition($line, $file, $Pass))
         $Pass()
     end)
 end

--- a/src/pass.jl
+++ b/src/pass.jl
@@ -60,7 +60,7 @@ macro pass(transform)
         import Cassette.__overdub_generator__
         struct $Pass <: $Cassette.AbstractPass end
         (::Type{$Pass})(ctxtype, reflection) = $transform(ctxtype, reflection)
-        Core.eval($__module__, $Cassette.overdub_definition($line, $file, $Pass))
+        Core.eval($__module__, $Cassette.overdub_definition($line, $file))
         $Pass()
     end)
 end

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1,0 +1,33 @@
+using Pkg
+using Test
+
+testcode = raw"""
+module MyPkg
+
+using Cassette
+
+Cassette.@context Ctx
+const mypass = Cassette.@pass (ctx, ref) -> ref.code_info
+
+end # module
+"""
+
+mktempdir() do dir
+# for debugging use: 
+# let dir = mktempdir()
+# @show dir
+    cd(dir) do
+        Pkg.generate("MyPkg")
+        open(joinpath("MyPkg", "src", "MyPkg.jl"), "w") do io
+            write(io, testcode)
+        end
+        Pkg.activate("MyPkg")
+        Pkg.develop(PackageSpec(path=joinpath(@__DIR__, ".."))) # add Cassette
+
+        run(pipeline(`$(Base.julia_cmd()) --project=./MyPkg -e "using MyPkg"`, stderr="errs.log"))
+        errs = read("errs.log", String)
+        @test !occursin("WARNING: Method definition overdub", errs)
+    end
+end
+
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,3 +12,7 @@ println("running misc. tests (w/o tagging)")
 
 println("running misc. tests (w/ tagging)")
 @time @testset "misc. tests (w/ tagging)" begin include("misctaggingtests.jl") end
+
+# note should always be last
+println("running precompile test")
+include("precompile.jl")


### PR DESCRIPTION
as @vchuravy mentioned, adds the pass type back to the overdub/recurse generated function signatures.

@vchuravy @oxinabox any good ideas for tests for this? I still couldn't repro using:

```
module MyPkg

using Cassette

Cassette.@context Ctx
const mypass = Cassette.@pass (ctx, ref) -> ref.code_info

end # module
```

in a precompiled module. Loading MagneticReadHead triggered it, though, and this seems to fix that at least.