### PR TITLE
Specialise less

### DIFF
--- a/src/context.jl
+++ b/src/context.jl
@@ -471,8 +471,8 @@ Note that unlike `overdub`, `fallback`, etc., this function is not intended to b
 
 See also:  [`overdub`](@ref), [`fallback`](@ref), [`recurse`](@ref)
 """
-@inline canrecurse(ctx::Context, f, ::Vararg{Any}) = !(isa(untag(f, ctx), Core.Builtin) || _iscompilerfunc(untag(f, ctx)))
-@inline canrecurse(ctx::Context, ::typeof(Core._apply), f, args...) = Core._apply(canrecurse, (ctx, f), args...)
-@inline canrecurse(ctx::Context, ::typeof(Core.invoke), f, _, args...) = canrecurse(ctx, f, args...)
+@inline canrecurse(ctx::Context, f, @nospecialize(args...)) = !(isa(untag(f, ctx), Core.Builtin) || _iscompilerfunc(untag(f, ctx)))
+@inline canrecurse(ctx::Context, ::typeof(Core._apply), f, @nospecialize(args...)) = Core._apply(canrecurse, (ctx, f), args...)
+@inline canrecurse(ctx::Context, ::typeof(Core.invoke), f, @nospecialize(_), @nospecialize(args...)) = canrecurse(ctx, f, args...)
 
 _iscompilerfunc(::F) where {F} = Core.Compiler.typename(F).module === Core.Compiler


### PR DESCRIPTION
Type inference time is the bane of performant overdubbing.
In MagnerticReadHead we spend a ton of time on it.
The flamechart below is for *after* the change to not specialise on the arguments (other than `f`) for `canrecurse`, which removed (so still a long way to go).
This change resulted in a 30% speedup for MagneticReadHead.

<img width="1285" alt="image" src="https://user-images.githubusercontent.com/5127634/57194041-c591da80-6f39-11e9-893d-c9dfde2f1b2c.png">
All the very tall flames are type-inference, I've highlighted two of the larger ones.
There used to be more of them but the `@nospecialize` in `can_recurse` removed some