### PR TITLE
implement splatnew

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ language: julia
 os:
   - linux
 julia:
-  - 0.7
   - 1.0
+  - 1.1
+  - 1.2
   - nightly
 matrix:
   allow_failures:

--- a/src/overdub.jl
+++ b/src/overdub.jl
@@ -261,7 +261,7 @@ function overdub_pass!(reflection::Reflection,
                                 i >= original_code_start_index || return nothing
                                 stmt = Base.Meta.isexpr(x, :(=)) ? x.args[2] : x
                                 Base.Meta.isexpr(stmt, :replaceglobalref) && return 1
-                                if isa(stmt, Expr) # Base.Meta.isexpr(stmt, :call) || Base.Meta.isexpr(stmt, :new) || Base.Meta.isexpr(stmt, :return)
+                                if isa(stmt, Expr)
                                     count = 0
                                     for arg in stmt.args
                                         if Base.Meta.isexpr(arg, :replaceglobalref)
@@ -280,7 +280,7 @@ function overdub_pass!(reflection::Reflection,
                                     globalref = stmt.args[2]
                                     name = QuoteNode(globalref.name)
                                     result = Expr(:call, Expr(:nooverdub, GlobalRef(Cassette, :tagged_globalref)), overdub_ctx_slot, tagmodssa, name, globalref)
-                                elseif isa(stmt, Expr) # Base.Meta.isexpr(stmt, :call) || Base.Meta.isexpr(stmt, :new) || Base.Meta.isexpr(stmt, :return)
+                                elseif isa(stmt, Expr)
                                     result = Expr(stmt.head)
                                     for arg in stmt.args
                                         if Base.Meta.isexpr(arg, :replaceglobalref)
@@ -350,21 +350,15 @@ function overdub_pass!(reflection::Reflection,
                             ])
     end
 
-    #=== replace `Expr(:new, ...)` with `Expr(:call, :tagged_new)` if tagging is enabled ===#
+    #=== replace `Expr(:new, ...)`/`Expr(:splatnew, ...)` with                            ===#
+    #=== `Expr(:call, :tagged_new)`/`Expr(:call, :tagged_splatnew)` if tagging is enabled ===#
 
     if istaggingenabled && !iskwfunc
-        replace_match!(x -> Base.Meta.isexpr(x, :new), overdubbed_code) do x
-            return Expr(:call, Expr(:nooverdub, GlobalRef(Cassette, :tagged_new)), overdub_ctx_slot, x.args...)
+        replace_match!(x -> Base.Meta.isexpr(x, :new) || Base.Meta.isexpr(x, :splatnew), overdubbed_code) do x
+            tagged_version = x.head == :new ? :tagged_new : :tagged_splatnew
+            return Expr(:call, Expr(:nooverdub, GlobalRef(Cassette, tagged_version)), overdub_ctx_slot, x.args...)
         end
     end
-
-    #=== replace `Expr(:splatnew, ...)` with `Expr(:call, :tagged_splatnew)` if tagging is enabled ===#
-    if istaggingenabled && !iskwfunc
-        replace_match!(x -> Base.Meta.isexpr(x, :splatnew), overdubbed_code) do x
-            return Expr(:call, Expr(:nooverdub, GlobalRef(Cassette, :tagged_splatnew)), overdub_ctx_slot, x.args...)
-        end
-    end
-
 
     #=== replace `Expr(:call, ...)` with `Expr(:call, :overdub, ...)` calls ===#
 


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/30577 introduced `Expr(:splatnew)`, causing #124 

This is nearly there, except that I haven't figured out what I need to do for metametadata..., @jrevels maybe we also want to unify the implementation of `tagged_new` and `tagged_splatnew`

```
 Error During Test at /home/vchuravy/src/Cassette/test/misctaggingtests.jl:264
  Test threw exception
  Expression: overdub(ctx, (_y->begin
                kwargtest(3; y=_y)
            end), tag(2, ctx)) === 5
  MethodError: Cannot `convert` an object of type Tuple{Cassette.Immutable{Cassette.Meta{Cassette.NoMetaData,Cassette.NoMetaMeta}}} to an object of type Cassette.NoMetaMeta
  Closest candidates are:
    convert(::Type{T}, !Matched::T) where T at essentials.jl:167
  Stacktrace:
   [1] _metametaconvert(::Type, ::Tuple{Cassette.Immutable{Cassette.Meta{Cassette.NoMetaData,Cassette.NoMetaMeta}}}) at /home/vchuravy/src/Cassette/src/tagging.jl:39
   [2] convert at /home/vchuravy/src/Cassette/src/tagging.jl:56 [inlined]
   [3] macro expansion at /home/vchuravy/src/Cassette/src/tagging.jl:521 [inlined]
   [4] tagged_splatnew(::Cassette.Context{nametype(KwargCtx),Nothing,Cassette.Tag{nametype(KwargCtx),0xfddc2783aa6f0228,Nothing},getfield(Cassette, Symbol("##PassType#375")),IdDict{Module,Dict{Symbol,Cassette.BindingMeta}},Nothing}, ::Type{NamedTuple{(:y,),Tuple{Int64}}}, ::Tagged{Cassette.Tag{nametype(KwargCtx),0xfddc2783aa6f0228,Nothing},Tuple{Int64},Cassette.NoMetaData,Tuple{Cassette.Immutable{Cassette.Meta{Cassette.NoMetaData,Cassette.NoMetaMeta}}},Cassette.Context{nametype(KwargCtx),Nothing,Cassette.Tag{nametype(KwargCtx),0xfddc2783aa6f0228,Nothing},getfield(Cassette, Symbol("##PassType#375")),IdDict{Module,Dict{Symbol,Cassette.BindingMeta}},Nothing}}) at /home/vchuravy/src/Cassette/src/tagging.jl:497
   [5] overdub(::Cassette.Context{nametype(KwargCtx),Nothing,Cassette.Tag{nametype(KwargCtx),0xfddc2783aa6f0228,Nothing},getfield(Cassette, Symbol("##PassType#375")),IdDict{Module,Dict{Symbol,Cassette.BindingMeta}},Nothing}, ::Type{NamedTuple{(:y,),Tuple{Int64}}}, ::Tagged{Cassette.Tag{nametype(KwargCtx),0xfddc2783aa6f0228,Nothing},Tuple{Int64},Cassette.NoMetaData,Tuple{Cassette.Immutable{Cassette.Meta{Cassette.NoMetaData,Cassette.NoMetaMeta}}},Cassette.Context{nametype(KwargCtx),Nothing,Cassette.Tag{nametype(KwargCtx),0xfddc2783aa6f0228,Nothing},getfield(Cassette, Symbol("##PassType#375")),IdDict{Module,Dict{Symbol,Cassette.BindingMeta}},Nothing}}) at ./boot.jl:553
   [6] overdub(::Cassette.Context{nametype(KwargCtx),Nothing,Cassette.Tag{nametype(KwargCtx),0xfddc2783aa6f0228,Nothing},getfield(Cassette, Symbol("##PassType#375")),IdDict{Module,Dict{Symbol,Cassette.BindingMeta}},Nothing}, ::Type{NamedTuple{(:y,),T} where T<:Tuple}, ::Tagged{Cassette.Tag{nametype(KwargCtx),0xfddc2783aa6f0228,Nothing},Tuple{Int64},Cassette.NoMetaData,Tuple{Cassette.Immutable{Cassette.Meta{Cassette.NoMetaData,Cassette.NoMetaMeta}}},Cassette.Context{nametype(KwargCtx),Nothing,Cassette.Tag{nametype(KwargCtx),0xfddc2783aa6f0228,Nothing},getfield(Cassette, Symbol("##PassType#375")),IdDict{Module,Dict{Symbol,Cassette.BindingMeta}},Nothing}}) at ./boot.jl:549
   [7] #145 at ./none:0 [inlined]
   [8] overdub(::Cassette.Context{nametype(KwargCtx),Nothing,Cassette.Tag{nametype(KwargCtx),0xfddc2783aa6f0228,Nothing},getfield(Cassette, Symbol("##PassType#375")),IdDict{Module,Dict{Symbol,Cassette.BindingMeta}},Nothing}, ::getfield(Main, Symbol("##145#146")), ::Tagged{Cassette.Tag{nametype(KwargCtx),0xfddc2783aa6f0228,Nothing},Int64,Cassette.NoMetaData,Cassette.NoMetaMeta,Cassette.Context{nametype(KwargCtx),Nothing,Cassette.Tag{nametype(KwargCtx),0xfddc2783aa6f0228,Nothing},getfield(Cassette, Symbol("##PassType#375")),IdDict{Module,Dict{Symbol,Cassette.BindingMeta}},Nothing}}) at /home/vchuravy/src/Cassette/src/overdub.jl:0
   [9] top-level scope at /home/vchuravy/src/Cassette/test/misctaggingtests.jl:264
   [10] include at ./boot.jl:328 [inlined]
   [11] include_relative(::Module, ::String) at ./loading.jl:1094
   [12] include(::Module, ::String) at ./Base.jl:31
   [13] include(::String) at ./client.jl:431
   [14] top-level scope at /home/vchuravy/src/Cassette/test/runtests.jl:14
   [15] top-level scope at /home/vchuravy/builds/julia/usr/share/julia/stdlib/v1.3/Test/src/Test.jl:1113
   [16] top-level scope at /home/vchuravy/src/Cassette/test/runtests.jl:14
   [17] top-level scope at util.jl:156
```