### PR TITLE
Support at-overdub with assignments

### DIFF
--- a/src/overdub.jl
+++ b/src/overdub.jl
@@ -660,5 +660,8 @@ macro roughly expands to `Cassette.recurse(ctx, () -> expression)`.
 See also: [`overdub`](@ref), [`recurse`](@ref)
 """
 macro overdub(ctx, expr)
+    if Base.Meta.isexpr(expr, :(=))
+        return Expr(:(=), esc(expr.args[1]), :(@overdub($(esc(ctx)), $(esc(expr.args[2])))))
+    end
     return :(recurse($(esc(ctx)), () -> $(esc(expr))))
 end


### PR DESCRIPTION
This very basic change allows you to at-overdub a single expression that assigns to a value, which is useful if, for example, you are implementing a cassette transform in a custom REPL