### PR TITLE
don't splat into _apply calls

### DIFF
--- a/src/context.jl
+++ b/src/context.jl
@@ -257,7 +257,7 @@ macro context(_Ctx)
 
         @inline Cassette.overdub(::C, ::Typeof(Tag), ::Type{N}, ::Type{X}) where {C<:$Ctx,N,X} = Tag(N, X, tagtype(C))
 
-        @inline Cassette.overdub(ctx::$Ctx, ::typeof(Core._apply), f, args...) = Core._apply(overdub, (ctx, f), args...)
+        @inline Cassette.overdub(ctx::$Ctx, ::typeof(Core._apply), f, args...) = Core._apply(overdub, (ctx, f), args)
 
         # TODO: There are certain non-`Core.Builtin` functions which the compiler often
         # relies upon constant propagation/tfuncs to infer, instead of specializing on
@@ -472,7 +472,7 @@ Note that unlike `overdub`, `fallback`, etc., this function is not intended to b
 See also:  [`overdub`](@ref), [`fallback`](@ref), [`recurse`](@ref)
 """
 @inline canrecurse(ctx::Context, f, ::Vararg{Any}) = !(isa(untag(f, ctx), Core.Builtin) || _iscompilerfunc(untag(f, ctx)))
-@inline canrecurse(ctx::Context, ::typeof(Core._apply), f, args...) = Core._apply(canrecurse, (ctx, f), args...)
+@inline canrecurse(ctx::Context, ::typeof(Core._apply), f, args...) = Core._apply(canrecurse, (ctx, f), args)
 @inline canrecurse(ctx::Context, ::typeof(Core.invoke), f, _, args...) = canrecurse(ctx, f, args...)
 
 _iscompilerfunc(::F) where {F} = Core.Compiler.typename(F).module === Core.Compiler


### PR DESCRIPTION
In  https://github.com/vchuravy/GPUifyLoops.jl/pull/88 I noticed that calls like `f(a, b, args...) = Core._apply(g, (a, b), args...)` 
where not being inlined, whereas `f(a, b, args...) = Core._apply(f, (a, b), args)` will be inlined.

@jrevels I am not sure if that impacts any of the `_apply` handling in `overdub.jl`.