### PR TITLE
Fix for #89, overdub with invoke and optional arguments

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,16 +2,14 @@ name = "Cassette"
 uuid = "7057c7e9-c182-5462-911a-8362d720325c"
 version = "0.2.4"
 
-[deps]
-
 [compat]
 julia = "1"
 
 [extras]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "LinearAlgebra", "InteractiveUtils", "Pkg"]

--- a/src/overdub.jl
+++ b/src/overdub.jl
@@ -166,7 +166,7 @@ function overdub_pass!(reflection::Reflection,
     n_prepended_slots = 3
     overdub_ctx_slot = SlotNumber(2)
     overdub_args_slot = SlotNumber(3)
-    invoke_offset = is_invoke ? 2 : 0
+    invoke_offset = is_invoke ? 1 : 0
 
     # For the sake of convenience, the rest of this pass will translate `code_info`'s fields
     # into these overdubbed equivalents instead of updating `code_info` in-place. Then, at
@@ -180,6 +180,9 @@ function overdub_pass!(reflection::Reflection,
     for i in 1:n_method_args
         slot = i + n_prepended_slots
         offset = i + invoke_offset
+        if is_invoke && i == 1
+            invoke_offset += 1
+        end
         if is_invoke && is_calloverload && i == 1
             offset = 2 # 1 is invoke, 2 is f, 3 is Tuple{}, 4... is args
         end

--- a/src/overdub.jl
+++ b/src/overdub.jl
@@ -141,12 +141,6 @@ function overdub_pass!(reflection::Reflection,
     iskwfunc = startswith(name, "#kw##")
     istaggingenabled = hastagging(context_type)
 
-    is_calloverload = false
-    if length(code_info.slotnames) > 0
-        # TODO: is this sufficient?
-        is_calloverload = first(code_info.slotnames) !== Symbol("#self#")
-    end
-
     #=== execute user-provided pass (is a no-op by default) ===#
 
     if !iskwfunc
@@ -166,7 +160,6 @@ function overdub_pass!(reflection::Reflection,
     n_prepended_slots = 3
     overdub_ctx_slot = SlotNumber(2)
     overdub_args_slot = SlotNumber(3)
-    invoke_offset = is_invoke ? 1 : 0
 
     # For the sake of convenience, the rest of this pass will translate `code_info`'s fields
     # into these overdubbed equivalents instead of updating `code_info` in-place. Then, at
@@ -177,19 +170,20 @@ function overdub_pass!(reflection::Reflection,
     # destructure the generated argument slots into the overdubbed method's argument slots.
     n_actual_args = fieldcount(signature)
     n_method_args = Int(method.nargs)
+    offset = 1
     for i in 1:n_method_args
+        if is_invoke && (i == 1 || i == 2)
+            # With an invoke call, we have: 1 is invoke, 2 is f, 3 is Tuple{}, 4... is args.
+            # In the first loop iteration, we should skip invoke and process f.
+            # In the second loop iteration, we should skip the Tuple type and process args[1].
+            offset += 1
+        end
         slot = i + n_prepended_slots
-        offset = i + invoke_offset
-        if is_invoke && i == 1
-            invoke_offset += 1
-        end
-        if is_invoke && is_calloverload && i == 1
-            offset = 2 # 1 is invoke, 2 is f, 3 is Tuple{}, 4... is args
-        end
         actual_argument = Expr(:call, GlobalRef(Core, :getfield), overdub_args_slot, offset)
         push!(overdubbed_code, :($(SlotNumber(slot)) = $actual_argument))
         push!(overdubbed_codelocs, code_info.codelocs[1])
         code_info.slotflags[slot] |= 0x02 # ensure this slotflag has the "assigned" bit set
+        offset += 1
     end
 
     # If `method` is a varargs method, we have to restructure the original method call's
@@ -206,9 +200,10 @@ function overdub_pass!(reflection::Reflection,
             trailing_arguments = Expr(:call, GlobalRef(Core, :tuple))
         end
         for i in n_method_args:n_actual_args
-            push!(overdubbed_code, Expr(:call, GlobalRef(Core, :getfield), overdub_args_slot, i + invoke_offset))
+            push!(overdubbed_code, Expr(:call, GlobalRef(Core, :getfield), overdub_args_slot, offset - 1))
             push!(overdubbed_codelocs, code_info.codelocs[1])
             push!(trailing_arguments.args, SSAValue(length(overdubbed_code)))
+            offset += 1
         end
         push!(overdubbed_code, Expr(:(=), SlotNumber(n_method_args + n_prepended_slots), trailing_arguments))
         push!(overdubbed_codelocs, code_info.codelocs[1])

--- a/test/misctests.jl
+++ b/test/misctests.jl
@@ -423,6 +423,26 @@ println("done (took ", time() - before_time, " seconds)")
 
 #############################################################################################
 
+print("   running Invoke2Ctx test...")
+
+before_time = time()
+
+# issue #89
+invoked2(x::Int) = x + x
+invoked2(x::Number, y=4) = x^2 + y
+invoker2(x) = invoke(invoked2, Tuple{Number}, x)
+
+@context Invoke2Ctx
+Cassette.prehook(ctx::Invoke2Ctx, f, args...) = push!(ctx.metadata, f)
+ctx = Invoke2Ctx(metadata=Any[])
+
+@test overdub(ctx, invoker2, 3) === invoker2(3) === 13
+
+println("done (took ", time() - before_time, " seconds)")
+
+
+#############################################################################################
+
 # taken from https://stackoverflow.com/questions/52050262/how-to-do-memoization-or-memoisation-in-julia-1-0/52062639#52062639
 
 print("   running MemoizeCtx test...")


### PR DESCRIPTION
I'm still trying to wrap my head around the package internals, but this seems to fix #89 and I think this kind of makes sense. The old behavior of adding a constant `invoke_offset` of 2 to all argument slots seemed kind of weird to me, since `untagged_args` in `__overdub_generator__` ends up looking like `(typeof(invoke), typeof(f), Type{Tuple{Int64}}, Int64)`, i.e. the first and third arguments should be skipped, rather than the first two.