### PR TITLE
Remove `assert edges == nothing` since now Cassette isn't the only one using CodeInfo.edges! :)

### DIFF
--- a/src/overdub.jl
+++ b/src/overdub.jl
@@ -80,8 +80,11 @@ function reflect(@nospecialize(sigtypes::Tuple), world::UInt = typemax(UInt))
     code_info = copy_code_info(code_info)
 @static if VERSION >= v"1.3.0-DEV.379"
         edges = Core.MethodInstance[method_instance]
-        @assert code_info.edges === nothing
-        code_info.edges = edges
+        if code_info.edges === nothing
+            code_info.edges = edges
+        else
+            append!(code_info.edges, edges)
+        end
     end
     return Reflection(S, method, static_params, code_info)
 end


### PR DESCRIPTION
Since StagedFunctions.jl is now also setting CodeInfo.edges (along with
who knows who else!?), and since StagedFunctions.jl is using Cassette
(for now), it seems that Cassette can't assume it's the only one setting
forward edges on CodeInfos.

This commit makes it play-nice by appending to `edges` if it already exists.