### PR TITLE
Call pass function in newest world-age.

### DIFF
--- a/src/overdub.jl
+++ b/src/overdub.jl
@@ -144,7 +144,10 @@ function overdub_pass!(reflection::Reflection,
     #=== execute user-provided pass (is a no-op by default) ===#
 
     if !iskwfunc
-        code_info = passtype(context_type)(context_type, reflection)
+        # passtype is defined in the wrong world-age so we need to run it in the newest
+        # ideally we would add a edge from that function to the generated thunk, but
+        # alas that would require us, to trace all dynamic function calls. Here be dragons.
+        code_info = Core._apply_pure(passtype(context_type), (context_type, reflection))
         isa(code_info, Expr) && return code_info
     end
 
@@ -548,6 +551,7 @@ function overdub_definition(line, file)
         end
     end
 end
+eval(overdub_definition(@__LINE__, @__FILE__))
 
 @doc(
 """

--- a/src/pass.jl
+++ b/src/pass.jl
@@ -57,10 +57,8 @@ macro pass(transform)
     line = Expr(:quote, __source__.line)
     file = Expr(:quote, __source__.file)
     return esc(quote
-        import Cassette.__overdub_generator__
         struct $Pass <: $Cassette.AbstractPass end
         (::Type{$Pass})(ctxtype, reflection) = $transform(ctxtype, reflection)
-        Core.eval($__module__, $Cassette.overdub_definition($line, $file))
         $Pass()
     end)
 end

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1,0 +1,30 @@
+using Pkg
+using Test
+
+testcode = raw"""
+module MyPkg
+using Cassette
+Cassette.@context Ctx
+const mypass = Cassette.@pass (ctx, ref) -> ref.code_info
+end # module
+"""
+
+mktempdir() do dir
+# for debugging use:
+# let dir = mktempdir()
+# @show dir
+    cd(dir) do
+        Pkg.generate("MyPkg")
+        open(joinpath("MyPkg", "src", "MyPkg.jl"), "w") do io
+            write(io, testcode)
+        end
+        Pkg.activate("MyPkg")
+        Pkg.develop(PackageSpec(path=joinpath(@__DIR__, ".."))) # add Cassette
+
+        run(pipeline(`$(Base.julia_cmd()) --project=./MyPkg -e "using MyPkg"`, stderr="errs.log"))
+        errs = read("errs.log", String)
+        @testset "Precompilation" begin
+            @test_broken !occursin("WARNING: Method definition overdub", errs)
+        end
+    end
+end

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -24,7 +24,7 @@ mktempdir() do dir
         run(pipeline(`$(Base.julia_cmd()) --project=./MyPkg -e "using MyPkg"`, stderr="errs.log"))
         errs = read("errs.log", String)
         @testset "Precompilation" begin
-            @test_broken !occursin("WARNING: Method definition overdub", errs)
+            @test !occursin("WARNING: Method definition overdub", errs)
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,3 +12,7 @@ println("running misc. tests (w/o tagging)")
 
 println("running misc. tests (w/ tagging)")
 @time @testset "misc. tests (w/ tagging)" begin include("misctaggingtests.jl") end
+
+# note should always be last
+println("running precompile test")
+include("precompile.jl")


### PR DESCRIPTION
Sometimes it helps to take a step back to remember why we do what we do. The method overwrite for `overdub` is done because the pass is defined by the user in a world-age after the definition of overdub. Instead of overwritting it (and running into issues during precompilation), we can call the pass function always in the newest world-age. 

fixes #113 

cc: @nhdaly