### PR TITLE
Adds now-passing test of Overdubbing an Overdub (adding edges to function with edges)

### DIFF
--- a/test/misctests.jl
+++ b/test/misctests.jl
@@ -663,3 +663,13 @@ let d = Dense(3,3)
     data = rand(3)
     Cassette.overdub(CtxCallOverload(), d, data)
 end
+
+#############################################################################################
+
+print("   running OverdubOverdubCtx test...")
+
+# Fixed in PR #148
+Cassette.@context OverdubOverdubCtx;
+f() = 2
+Cassette.overdub(OverdubOverdubCtx(), Cassette.overdub, OverdubOverdubCtx(), f)
+

--- a/test/misctests.jl
+++ b/test/misctests.jl
@@ -670,6 +670,5 @@ print("   running OverdubOverdubCtx test...")
 
 # Fixed in PR #148
 Cassette.@context OverdubOverdubCtx;
-f() = 2
-Cassette.overdub(OverdubOverdubCtx(), Cassette.overdub, OverdubOverdubCtx(), f)
-
+overdub_overdub_me() = 2
+Cassette.overdub(OverdubOverdubCtx(), Cassette.overdub, OverdubOverdubCtx(), overdub_overdub_me)


### PR DESCRIPTION
Adding unit test for change in https://github.com/jrevels/Cassette.jl/pull/148, which allows you to overdub a function whose CodeInfo already has edges, either because it was previously overdubbed, or because someone else set `edges` (e.g. https://github.com/NHDaly/StagedFunctions.jl)

Before #148 this failed, and after it now passes