### PR TITLE
ReflectOn: pick which method's body to rewrite

### DIFF
--- a/test/misctests.jl
+++ b/test/misctests.jl
@@ -666,9 +666,17 @@ end
 
 #############################################################################################
 
-print("   running OverdubOverdubCtx test...")
+println("   running OverdubOverdubCtx test...")
 
 # Fixed in PR #148
 Cassette.@context OverdubOverdubCtx;
 overdub_overdub_me() = 2
 Cassette.overdub(OverdubOverdubCtx(), Cassette.overdub, OverdubOverdubCtx(), overdub_overdub_me)
+
+print("   running ReflectOn test...")
+reflecton_test(x::Float64) = "float64"
+reflecton_test(x::Int) = "int"
+
+Cassette.@context ReflectOnCtx
+@test @inferred(Cassette.overdub(ReflectOnCtx(), Cassette.ReflectOn{Tuple{typeof(reflecton_test), Int}}(), 1.0)) == "int"
+@test @inferred(Cassette.overdub(ReflectOnCtx(), Cassette.ReflectOn{Tuple{typeof(reflecton_test), Float64}}(), 1)) == "float64"


### PR DESCRIPTION
We need this in ForwardDiff2 to make Dual numbers work on functions which are restricted to concrete number types, for example, `f(x::Float64) = x+1`.

This will allow us to take the method `f(::Float64)` and rewrite it while still using a `Dual` container type.