### PR TITLE
Make offset an argument of overdub_pass!

### DIFF
--- a/src/overdub.jl
+++ b/src/overdub.jl
@@ -127,7 +127,8 @@ const OVERDUB_ARGUMENTS_NAME = gensym("overdub_arguments")
 #   4. If tagging is enabled, do the necessary IR transforms for the metadata tagging system
 function overdub_pass!(reflection::Reflection,
                        context_type::DataType,
-                       is_invoke::Bool = false)
+                       is_invoke::Bool = false,
+                       offset::Int=1)
     signature = reflection.signature
     method = reflection.method
     static_params = reflection.static_params
@@ -175,7 +176,6 @@ function overdub_pass!(reflection::Reflection,
     # destructure the generated argument slots into the overdubbed method's argument slots.
     n_actual_args = fieldcount(signature)
     n_method_args = Int(method.nargs)
-    offset = 1
     for i in 1:n_method_args
         if is_invoke && (i == 1 || i == 2)
             # With an invoke call, we have: 1 is invoke, 2 is f, 3 is Tuple{}, 4... is args.


### PR DESCRIPTION
Given the hesitance to merge https://github.com/jrevels/Cassette.jl/pull/157, I'd like to implement `ReflectOn` in a separate package. However, `overdub_pass!` is a gigantic function and in order to make `ReflectOn` work, I'd need to copy paste all of `overdub_pass!` just so I can add `offset=2` for the `ReflectOn` method. Instead, I think it'd be nice if `offset` could just be an argument to `overdub_pass!`. I think this would be beneficial to others who might want to tweak or alter `overdub` as well in a similar way. 