### PR TITLE
Don't define overdub and recurse with eval

### DIFF
--- a/src/overdub.jl
+++ b/src/overdub.jl
@@ -523,37 +523,14 @@ function recurse end
 
 recurse(ctx::Context, ::typeof(Core._apply), f, args...) = Core._apply(recurse, (ctx, f), args...)
 
-function overdub_definition(line, file)
-    return quote
-        function $Cassette.overdub($OVERDUB_CONTEXT_NAME::$Cassette.Context, $OVERDUB_ARGUMENTS_NAME...)
-            $(Expr(:meta, :generated_only))
-            $(Expr(:meta,
-                   :generated,
-                   Expr(:new,
-                        Core.GeneratedFunctionStub,
-                        :__overdub_generator__,
-                        Any[:overdub, OVERDUB_CONTEXT_NAME, OVERDUB_ARGUMENTS_NAME],
-                        Any[],
-                        line,
-                        QuoteNode(Symbol(file)),
-                        true)))
-        end
-        function $Cassette.recurse($OVERDUB_CONTEXT_NAME::$Cassette.Context, $OVERDUB_ARGUMENTS_NAME...)
-            $(Expr(:meta, :generated_only))
-            $(Expr(:meta,
-                   :generated,
-                   Expr(:new,
-                        Core.GeneratedFunctionStub,
-                        :__overdub_generator__,
-                        Any[:recurse, OVERDUB_CONTEXT_NAME, OVERDUB_ARGUMENTS_NAME],
-                        Any[],
-                        line,
-                        QuoteNode(Symbol(file)),
-                        true)))
-        end
-    end
+
+@generated function overdub(ctx::Context, args...)
+    return __overdub_generator__(overdub, ctx, args)
 end
-eval(overdub_definition(@__LINE__, @__FILE__))
+
+@generated function recurse(ctx::Context, args...)
+    return __overdub_generator__(recurse, ctx, args)
+end
 
 @doc(
 """

--- a/test/misctests.jl
+++ b/test/misctests.jl
@@ -206,6 +206,8 @@ println("done (took ", time() - before_time, " seconds)")
 
 #############################################################################################
 
+# OVERDUB_ARGUMENTS_NAME is no longer defined. Not sure what this test is doing so I can't fix it. 
+
 print("   running PassFallbackCtx test...")
 
 before_time = time()
@@ -213,7 +215,7 @@ before_time = time()
 @context PassFallbackCtx
 fallbackpass = @pass (ctx, ref) -> begin
     if ref.signature <: Tuple{typeof(sin),Any}
-        return :(cos($(Cassette.OVERDUB_ARGUMENTS_NAME)[2]))
+        return :(cos(args[2]))
     end
     return ref.code_info
 end


### PR DESCRIPTION
Lets see if we still need to define these with `eval`. 