### PR TITLE
Check for keyword function names differently on 1.4+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.jl.mem
 docs/build/
 docs/site/
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Cassette"
 uuid = "7057c7e9-c182-5462-911a-8362d720325c"
-version = "0.3.2"
+version = "0.3.3"
 
 [compat]
 julia = "1"

--- a/test/misctests.jl
+++ b/test/misctests.jl
@@ -294,11 +294,7 @@ end
 tracekw = Any[]
 @overdub(TraceCtx(metadata = tracekw), trkwtest(x, _y = y, _z = z)) == trtest(x, y, z)
 subtracekw = first(Iterators.filter(t -> t[1] === (Core.kwfunc(trkwtest), (_y = y, _z = z), trkwtest, x), tracekw))[2]
-if VERSION < v"1.4"
-    @test subtracekw == trace
-else
-    @test_broken subtracekw == trace
-end
+@test subtracekw == trace
 
 function enter!(t::HookTrace, args...)
     pair = args => Any[]
@@ -382,7 +378,7 @@ if VERSION <= v"1.3"
 else
     # test depends on constant propagation
     @test_throws Exception @inferred(overdub(InferCtx(), *, rand(Float32, 1, 1), rand(Float32, 1)))
-    # test depends on M*v which is the test above 
+    # test depends on M*v which is the test above
     @test_throws Exception @inferred(overdub(InferCtx(), relulayer, rand(Float64, 1, 1), rand(Float32, 1), rand(Float32, 1)))
     # XXX: Figure out why this broke
     @test_throws Exception @inferred(overdub(InferCtx(), rand, Float32, 1))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using Test, Cassette, LinearAlgebra
 using Cassette: @context, @pass, @overdub, overdub, recurse, hasmetadata,
                 metadata, hasmetameta, metameta, untag, tag, enabletagging,
                 untagtype, istagged, istaggedtype, Tagged, fallback, canrecurse,
-                similarcontext, disablehooks
+                similarcontext, disablehooks, iskwftype
 
 println("running unit tests")
 @time @testset "unit tests" begin include("unittests.jl") end

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -40,3 +40,13 @@ end
 
 @context FooBar
 @context FooBar
+
+# Test keyword function detection
+kwtest_1(; x) = x  # Normal function
+const kwtest_2 = (; x) -> x  # Anonymous function
+const kwtest_3  = let; (; x) -> x end  # Closure
+for n in 1:3
+    F = typeof(getfield(Main, Symbol(:kwtest_, n)))
+    @test iskwftype(Core.kwftype(F))
+    @test !iskwftype(F)
+end


### PR DESCRIPTION
In https://github.com/christopher-dG/SimpleMock.jl/pull/11 I found that the names of keyword wrapper functions follow a different scheme starting with Julia 1.4.
I think we can apply the same thing here!

I was hoping that this change would make the `Skipped` workaround in the above PR unnecessary, but that doesn't seem to be the case. I'll probably come up with a good MWE and open a new issue about that later.

Closes #161 