### PR TITLE
remove show on the generated context type

### DIFF
--- a/src/context.jl
+++ b/src/context.jl
@@ -248,8 +248,6 @@ macro context(_Ctx)
     return quote
         struct $CtxName <: AbstractContextName end
 
-        Base.show(io::IO, ::Type{$CtxName}) = print(io, "nametype(", $(string(_Ctx)), ")")
-
         const $Ctx{$M,$T<:Union{Nothing,Tag}} = Context{$CtxName,$M,$T}
         const $CtxTagged = ContextTagged{$T,$CtxName} where {$T<:Tag}
 


### PR DESCRIPTION
This causes catastrofic invalidations and cannot really be worth it

As a demonstration:

<img width="1728" alt="Screenshot 2023-11-17 at 13 50 10" src="https://github.com/JuliaLabs/Cassette.jl/assets/1282691/e39052c7-61a4-4eb5-a6b6-2278491c9e84">

Here, FunctionProperties.jl uses `@context` and immediately causes 12k invalidations (can be seen by looking at the invalidation plot).